### PR TITLE
feat: add globalConfig.status for preview status of the form

### DIFF
--- a/packages/ncform-common/src/mixins/vue/control-mixin.js
+++ b/packages/ncform-common/src/mixins/vue/control-mixin.js
@@ -68,7 +68,7 @@ export default {
 
   computed: {
     disabled() {
-      return this._analyzeVal(this.config.disabled);
+      return this.globalConst.disabled || this._analyzeVal(this.config.disabled);
     },
     readonly() {
       return this._analyzeVal(this.config.readonly);

--- a/packages/ncform-common/src/mixins/vue/control-mixin.js
+++ b/packages/ncform-common/src/mixins/vue/control-mixin.js
@@ -72,7 +72,7 @@ export default {
 
   computed: {
     disabled() {
-      return this._analyzeVal(this.config.disabled);
+      return this.globalStatus === 'preview' || this._analyzeVal(this.config.disabled);
     },
     readonly() {
       return this._analyzeVal(this.config.readonly);

--- a/packages/ncform-common/src/mixins/vue/control-mixin.js
+++ b/packages/ncform-common/src/mixins/vue/control-mixin.js
@@ -68,7 +68,7 @@ export default {
 
   computed: {
     disabled() {
-      return this.globalConst.disabled || this._analyzeVal(this.config.disabled);
+      return this._analyzeVal(this.globalConst.disabled) || this._analyzeVal(this.config.disabled);
     },
     readonly() {
       return this._analyzeVal(this.config.readonly);

--- a/packages/ncform-common/src/mixins/vue/control-mixin.js
+++ b/packages/ncform-common/src/mixins/vue/control-mixin.js
@@ -48,6 +48,10 @@ export default {
       type: Object
     },
 
+    globalStatus: {
+      type: String
+    },
+
     idxChain: {
       type: String,
       default: ""
@@ -68,7 +72,7 @@ export default {
 
   computed: {
     disabled() {
-      return this._analyzeVal(this.globalConst.disabled) || this._analyzeVal(this.config.disabled);
+      return this._analyzeVal(this.config.disabled);
     },
     readonly() {
       return this._analyzeVal(this.config.readonly);

--- a/packages/ncform-common/src/mixins/vue/layout-array-mixin.js
+++ b/packages/ncform-common/src/mixins/vue/layout-array-mixin.js
@@ -57,6 +57,10 @@ export default {
       type: Object
     },
 
+    globalStatus: {
+      type: String
+    },
+
     idxChain: {
       type: String,
       default: ""
@@ -88,7 +92,7 @@ export default {
 
   computed: {
     disabled() {
-      return this._analyzeVal(this.globalConst.disabled) || this._analyzeVal(this.config.disabled);
+      return this._analyzeVal(this.config.disabled);
     },
     mergeConfig() {
       let newConfig = extend(

--- a/packages/ncform-common/src/mixins/vue/layout-array-mixin.js
+++ b/packages/ncform-common/src/mixins/vue/layout-array-mixin.js
@@ -68,6 +68,7 @@ export default {
       collapsed: false,
       defaultConfig: {
         collapsed: false,
+        disabled: false,
         disableCollapse: false,
         disableReorder: false,
         disableAdd: false,
@@ -86,6 +87,9 @@ export default {
   },
 
   computed: {
+    disabled() {
+      return this.globalConst.disabled || this._analyzeVal(this.config.disabled);
+    },
     mergeConfig() {
       let newConfig = extend(
         true,

--- a/packages/ncform-common/src/mixins/vue/layout-array-mixin.js
+++ b/packages/ncform-common/src/mixins/vue/layout-array-mixin.js
@@ -88,7 +88,7 @@ export default {
 
   computed: {
     disabled() {
-      return this.globalConst.disabled || this._analyzeVal(this.config.disabled);
+      return this._analyzeVal(this.globalConst.disabled) || this._analyzeVal(this.config.disabled);
     },
     mergeConfig() {
       let newConfig = extend(

--- a/packages/ncform-common/src/mixins/vue/layout-object-mixin.js
+++ b/packages/ncform-common/src/mixins/vue/layout-object-mixin.js
@@ -33,6 +33,10 @@ export default {
       type: Object
     },
 
+    globalStatus: {
+      type: String
+    },
+
     idxChain: {
       type: String,
       default: ""

--- a/packages/ncform-common/src/ncform-utils.js
+++ b/packages/ncform-common/src/ncform-utils.js
@@ -135,6 +135,7 @@ const ncformUtils = {
         // 根节点
         const defaultGlobalConfig = {
           // 全局配置
+          status: "edit",
           style: {
             formCls: "", // form class
             invalidFeedbackCls: "" // invalid feedback class

--- a/packages/ncform-theme-elementui/examples/preview.html
+++ b/packages/ncform-theme-elementui/examples/preview.html
@@ -47,8 +47,8 @@
   <script type="text/javascript" src="https://unpkg.com/element-ui/lib/index.js"></script>
   <script src="https://unpkg.com/mockjs"></script>
   <script src="https://unpkg.com/js-url"></script>
-  <script type="text/javascript" src="../examples/dist/ncformCommon.min.js"></script>
-  <script type="text/javascript" src="../examples/dist/vueNcform.min.js"></script>
+  <script type="text/javascript" src="../../node_modules/@ncform/ncform-common/dist/ncformCommon.min.js"></script>
+  <script type="text/javascript" src="../../node_modules/@ncform/ncform/dist/vueNcform.js"></script>
   <script type="text/javascript" src="../dist/object.js"></script>
   <script type="text/javascript" src="../dist/array.js"></script>
   <script type="text/javascript" src="../dist/arrayTable.js"></script>
@@ -202,8 +202,7 @@
               "type": "array",
               "ui": {
                 "widget": "upload"
-              },
-              "items": {}
+              }
             },
             "label_1574213915336": {
               "type": "string",
@@ -348,7 +347,7 @@
             "rate_1574213912088": 4,
             "radio_1574213912736": true,
             "checkbox_1574213913432": true,
-            "upload_1574213914489": [],
+            "upload_1574213914489":  [{ "name": "girl.jpg", "url": "//user-gold-cdn.xitu.io/2019/3/15/1697f38df3ba0613?w=570&h=273&f=jpeg&s=40278", "uid": 1574927608606 }],
             "label_1574213915336": "",
             "switch_1574213915936": true,
             "object_1574213917664": {

--- a/packages/ncform-theme-elementui/examples/preview.html
+++ b/packages/ncform-theme-elementui/examples/preview.html
@@ -1,0 +1,403 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport"
+    content="width=device-width, initial-scale=1.0,minimum-scale=1.0, maximum-scale=1.0, minimal-ui" />
+  <title>preview demo</title>
+
+  <link rel="stylesheet" href="./demo.css" />
+
+  <!-- 引入样式 -->
+  <link rel="stylesheet" href="https://unpkg.com/element-ui/lib/theme-chalk/index.css">
+  <script>
+    var _hmt = _hmt || [];
+    (function () {
+      var hm = document.createElement("script");
+      hm.src = "https://hm.baidu.com/hm.js?027aa17f0e14133f0b8aa5f1f0af3ca7";
+      var s = document.getElementsByTagName("script")[0];
+      s.parentNode.insertBefore(hm, s);
+    })();
+  </script>
+</head>
+
+<body>
+  <!--演示区域-->
+  <div id="demo" v-cloak>
+    <div v-for="(item, idx) in formSchemas">
+      <h4 class="demo_title">{{ item.title }}</h4>
+      <div class="demo_item-wrapper">
+        <div>
+          <ncform :form-schema="item.schema" v-model="item.schema.value"></ncform>
+        </div>
+        <div>
+          <pre>{{ JSON.stringify(originFormSchemas[idx].schema.properties, null, 2) }}</pre>
+        </div>
+        <div>
+          <pre>{{ item.schema.value }}</pre>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script type="text/javascript" src="../node_modules/lodash/lodash.min.js"></script>
+  <script type="text/javascript" src="../node_modules/axios/dist/axios.min.js"></script>
+  <script type="text/javascript" src="https://unpkg.com/vue@2.6.10/dist/vue.min.js"></script>
+  <script type="text/javascript" src="https://unpkg.com/element-ui/lib/index.js"></script>
+  <script src="https://unpkg.com/mockjs"></script>
+  <script src="https://unpkg.com/js-url"></script>
+  <script type="text/javascript" src="../examples/dist/ncformCommon.min.js"></script>
+  <script type="text/javascript" src="../examples/dist/vueNcform.min.js"></script>
+  <script type="text/javascript" src="../dist/object.js"></script>
+  <script type="text/javascript" src="../dist/array.js"></script>
+  <script type="text/javascript" src="../dist/arrayTable.js"></script>
+  <script type="text/javascript" src="../dist/arrayTabs.js"></script>
+  <script type="text/javascript" src="../dist/checkbox.js"></script>
+  <script type="text/javascript" src="../dist/colorPicker.js"></script>
+  <script type="text/javascript" src="../dist/datePicker.js"></script>
+  <script type="text/javascript" src="../dist/input.js"></script>
+  <script type="text/javascript" src="../dist/inputNumber.js"></script>
+  <script type="text/javascript" src="../dist/label.js"></script>
+  <script type="text/javascript" src="../dist/radio.js"></script>
+  <script type="text/javascript" src="../dist/rate.js"></script>
+  <script type="text/javascript" src="../dist/select.js"></script>
+  <script type="text/javascript" src="../dist/slider.js"></script>
+  <script type="text/javascript" src="../dist/switch.js"></script>
+  <script type="text/javascript" src="../dist/textarea.js"></script>
+  <script type="text/javascript" src="../dist/upload.js"></script>
+
+  <script type="text/javascript">
+    let lang = 'en';
+
+    if (location.search.indexOf('lang=cn') >= 0) {
+      lang = 'cn';
+    }
+
+    Mock.mock(/getDomains/, function (options) {
+      return [{ id: 1, label: '.cn' }, { id: 2, label: '.com' }, { id: 3, label: '.net' }];
+    });
+    Mock.mock(/getKeywords/, function (options) {
+      let params = url('?', options.url) || {};
+      console.log('getKeywords:', params);
+      let result = [{ value: 'oppo' }, { value: 'xiaomi' }, { value: 'iphone' }, { value: 'iphone x' }, { value: 'iphone 6s' }];
+      return { data: result.filter(item => item.value.indexOf(params.keyword) >= 0) };
+    });
+
+    Vue.use(vueNcform, {
+      extComponents: {
+        object: object.default,
+        array: array.default,
+        arrayTable: arrayTable.default,
+        arrayTabs: arrayTabs.default,
+        checkbox: checkbox.default,
+        colorPicker: colorPicker.default,
+        datePicker: datePicker.default,
+        input: input.default,
+        inputNumber: inputNumber.default,
+        label: label.default,
+        radio: radio.default,
+        rate: rate.default,
+        select: select.default,
+        slider: slider.default,
+        switch: window.switch.default,
+        textarea: textarea.default,
+        upload: upload.default,
+      }, lang: lang === 'cn' ? 'zh_cn' : 'en'
+    });
+
+    let formSchemas = [
+      {
+        title: {
+          cn: '默认状态',
+          en: 'Default'
+        },
+        schema: {
+          "root": true,
+          "type": "object",
+          "properties": {
+            "input_1574213906497": {
+              "type": "string",
+              "ui": {
+                "widget": "input"
+              }
+            },
+            "input-number_1574213907169": {
+              "type": "number",
+              "ui": {
+                "widget": "input-number"
+              }
+            },
+            "textarea_1574213908025": {
+              "type": "string",
+              "ui": {
+                "widget": "textarea"
+              }
+            },
+            "select_1574213908817": {
+              "type": "string",
+              "ui": {
+                "widget": "select",
+                "widgetConfig": {
+                  "enumSource": [
+                    {
+                      "value": 1
+                    },
+                    {
+                      "value": 2
+                    }
+                  ]
+                },
+                "columns": 12,
+                "showLabel": true,
+                "noLabelSpace": false,
+                "showLegend": false,
+                "help": {
+                  "show": false,
+                  "text": "?"
+                },
+                "linkFields": []
+              },
+              "rules": {
+                "customRule": []
+              }
+            },
+            "color-picker_1574213909840": {
+              "type": "string",
+              "ui": {
+                "widget": "color-picker"
+              }
+            },
+            "date-picker_1574213910480": {
+              "type": "string",
+              "ui": {
+                "widget": "date-picker"
+              }
+            },
+            "slider_1574213911424": {
+              "type": "number",
+              "ui": {
+                "widget": "slider"
+              }
+            },
+            "rate_1574213912088": {
+              "type": "number",
+              "ui": {
+                "widget": "rate"
+              }
+            },
+            "radio_1574213912736": {
+              "type": "boolean",
+              "ui": {
+                "widget": "radio"
+              }
+            },
+            "checkbox_1574213913432": {
+              "type": "boolean",
+              "ui": {
+                "widget": "checkbox"
+              }
+            },
+            "upload_1574213914489": {
+              "type": "array",
+              "ui": {
+                "widget": "upload"
+              },
+              "items": {}
+            },
+            "label_1574213915336": {
+              "type": "string",
+              "default": "ccc",
+              "ui": {
+                "widget": "label"
+              }
+            },
+            "switch_1574213915936": {
+              "type": "boolean",
+              "ui": {
+                "widget": "switch"
+              }
+            },
+            "object_1574213917664": {
+              "type": "object",
+              "ui": {
+                "widget": "object",
+                "showLegend": false
+              },
+              "properties": {
+                "input_1574213923517": {
+                  "type": "string",
+                  "ui": {
+                    "widget": "input"
+                  }
+                },
+                "slider_1574213927660": {
+                  "type": "number",
+                  "ui": {
+                    "widget": "slider"
+                  }
+                }
+              }
+            },
+            "array_1574213918451": {
+              "type": "array",
+              "ui": {
+                "widget": "array",
+                "showLegend": false
+              },
+              "items": {
+                "type": "object",
+                "properties": {
+                  "color-picker_1574213937826": {
+                    "type": "string",
+                    "ui": {
+                      "widget": "color-picker"
+                    }
+                  },
+                  "input-number_1574213932330": {
+                    "type": "number",
+                    "ui": {
+                      "widget": "input-number"
+                    }
+                  }
+                }
+              }
+            },
+            "array-table_1574213919360": {
+              "type": "array",
+              "ui": {
+                "widget": "array-table",
+                "showLegend": false
+              },
+              "items": {
+                "type": "object",
+                "properties": {
+                  "radio_1574213946074": {
+                    "type": "boolean",
+                    "ui": {
+                      "widget": "radio"
+                    }
+                  },
+                  "rate_1574213943490": {
+                    "type": "number",
+                    "ui": {
+                      "widget": "rate"
+                    }
+                  }
+                }
+              }
+            },
+            "array-tabs_1574213920104": {
+              "type": "array",
+              "ui": {
+                "widget": "array-tabs",
+                "showLegend": false
+              },
+              "items": {
+                "type": "object",
+                "properties": {
+                  "select_1574213957686": {
+                    "type": "string",
+                    "ui": {
+                      "widget": "select",
+                      "widgetConfig": {
+                        "enumSource": [
+                          {
+                            "value": 1
+                          },
+                          {
+                            "value": 2
+                          }
+                        ]
+                      },
+                      "columns": 12,
+                      "showLabel": true,
+                      "noLabelSpace": false,
+                      "showLegend": false,
+                      "help": {
+                        "show": false,
+                        "text": "?"
+                      },
+                      "linkFields": []
+                    },
+                    "rules": {
+                      "customRule": []
+                    }
+                  },
+                  "switch_1574213950890": {
+                    "type": "boolean",
+                    "ui": {
+                      "widget": "switch"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "globalConfig": {
+            status: 'preview'
+          },
+          value: {
+            "input_1574213906497": "aaa",
+            "input-number_1574213907169": 3,
+            "textarea_1574213908025": "bbb",
+            "select_1574213908817": 2,
+            "color-picker_1574213909840": "#F10404",
+            "date-picker_1574213910480": "1573660800000",
+            "slider_1574213911424": 30,
+            "rate_1574213912088": 4,
+            "radio_1574213912736": true,
+            "checkbox_1574213913432": true,
+            "upload_1574213914489": [],
+            "label_1574213915336": "",
+            "switch_1574213915936": true,
+            "object_1574213917664": {
+              "input_1574213923517": "111",
+              "slider_1574213927660": 21
+            },
+            "array_1574213918451": [
+              {
+                "color-picker_1574213937826": "#57FF04",
+                "input-number_1574213932330": 5
+              }
+            ],
+            "array-table_1574213919360": [
+              {
+                "radio_1574213946074": true,
+                "rate_1574213943490": 2
+              },
+              {
+                "radio_1574213946074": false,
+                "rate_1574213943490": 4
+              }
+            ],
+            "array-tabs_1574213920104": [
+              {
+                "select_1574213957686": 1,
+                "switch_1574213950890": true
+              }
+            ]
+          }
+        }
+      }
+    ]
+    // Bootstrap the app
+    new Vue({
+      el: '#demo',
+      data: {
+        formSchemas: getFormSchemas(),
+        originFormSchemas: getFormSchemas()
+      }
+    });
+
+    function getFormSchemas() {
+      return formSchemas.map(item => ({
+        title: item.title[lang],
+        schema: item.schema,
+        detail: item.detail ? item.detail[lang] : ''
+      }));
+    }
+  </script>
+</body>
+
+</html>

--- a/packages/ncform-theme-elementui/src/components/control-comps/checkbox.vue
+++ b/packages/ncform-theme-elementui/src/components/control-comps/checkbox.vue
@@ -3,41 +3,36 @@
   class="ncform-checkbox"
   v-show="!hidden"
 >
-  <div v-if="globalStatus === 'preview'" class="ncform-checkbox-preview">
-    {{modelVal}}
-  </div>
-  <template v-else>
-    <el-checkbox
-      v-if="mergeConfig.selectAll && !readonly"
-      :class="'check-all'"
-      :disabled="disabled"
-      :indeterminate="isIndeterminate"
-      v-model="isCheckAll"
-      @change="handleCheckAllChange"
-    >{{$nclang('all')}}</el-checkbox>
+  <el-checkbox
+    v-if="mergeConfig.selectAll && !readonly"
+    :class="'check-all'"
+    :disabled="disabled"
+    :indeterminate="isIndeterminate"
+    v-model="isCheckAll"
+    @change="handleCheckAllChange"
+  >{{$nclang('all')}}</el-checkbox>
 
-    <el-checkbox-group
-      v-if="!readonly"
-      size="mini"
-      :disabled="disabled"
-      v-model="modelVal"
-      @change="handleCheckedOptChange"
-    >
-      <component :is="'el-checkbox' + (mergeConfig.type === 'button' ? '-button' : '')"
-        v-for="opt in dataSource"
-        :key="opt[mergeConfig.itemValueField]"
-        :label="opt[mergeConfig.itemValueField]"
-        :class="mergeConfig.type === 'checkbox' && mergeConfig.arrangement === 'v' ? 'is-vertical' : ''"
-      >{{opt[mergeConfig.itemLabelField]}}</component>
-    </el-checkbox-group>
+  <el-checkbox-group
+    v-if="!readonly"
+    size="mini"
+    :disabled="disabled"
+    v-model="modelVal"
+    @change="handleCheckedOptChange"
+  >
+    <component :is="'el-checkbox' + (mergeConfig.type === 'button' ? '-button' : '')"
+      v-for="opt in dataSource"
+      :key="opt[mergeConfig.itemValueField]"
+      :label="opt[mergeConfig.itemValueField]"
+      :class="mergeConfig.type === 'checkbox' && mergeConfig.arrangement === 'v' ? 'is-vertical' : ''"
+    >{{opt[mergeConfig.itemLabelField]}}</component>
+  </el-checkbox-group>
 
-    <label
-      v-show="readonly"
-      v-for="(label, idx) in labelRead"
-      :key="idx"
-      :class="['label-read', mergeConfig.type === 'checkbox' && mergeConfig.arrangement === 'v' ? 'label-vertical' : '']"
-    >{{label}}</label>
-  </template>
+  <label
+    v-show="readonly"
+    v-for="(label, idx) in labelRead"
+    :key="idx"
+    :class="['label-read', mergeConfig.type === 'checkbox' && mergeConfig.arrangement === 'v' ? 'label-vertical' : '']"
+  >{{label}}</label>
 </div>
 </template>
 
@@ -87,12 +82,6 @@
       &.label-vertical {
         display: block;
       }
-    }
-
-    .ncform-checkbox-preview {
-      color: #606266;
-      font-size: 14px;
-      line-height: 40px;
     }
   }
 </style>

--- a/packages/ncform-theme-elementui/src/components/control-comps/checkbox.vue
+++ b/packages/ncform-theme-elementui/src/components/control-comps/checkbox.vue
@@ -1,44 +1,44 @@
 <template>
-  <div
-    class="ncform-checkbox"
-    v-show="!hidden"
-  >
-    <div v-if="globalStatus === 'preview'" class="ncform-checkbox-preview">
-      {{modelVal}}
-    </div>
-    <template v-else>
-      <el-checkbox
-        v-if="mergeConfig.selectAll && !readonly"
-        :class="'check-all'"
-        :disabled="disabled"
-        :indeterminate="isIndeterminate"
-        v-model="isCheckAll"
-        @change="handleCheckAllChange"
-      >{{$nclang('all')}}</el-checkbox>
-
-      <el-checkbox-group
-        v-if="!readonly"
-        size="mini"
-        :disabled="disabled"
-        v-model="modelVal"
-        @change="handleCheckedOptChange"
-      >
-        <component :is="'el-checkbox' + (mergeConfig.type === 'button' ? '-button' : '')"
-          v-for="opt in dataSource"
-          :key="opt[mergeConfig.itemValueField]"
-          :label="opt[mergeConfig.itemValueField]"
-          :class="mergeConfig.type === 'checkbox' && mergeConfig.arrangement === 'v' ? 'is-vertical' : ''"
-        >{{opt[mergeConfig.itemLabelField]}}</component>
-      </el-checkbox-group>
-
-      <label
-        v-show="readonly"
-        v-for="(label, idx) in labelRead"
-        :key="idx"
-        :class="['label-read', mergeConfig.type === 'checkbox' && mergeConfig.arrangement === 'v' ? 'label-vertical' : '']"
-      >{{label}}</label>
-    </template>
+<div
+  class="ncform-checkbox"
+  v-show="!hidden"
+>
+  <div v-if="globalStatus === 'preview'" class="ncform-checkbox-preview">
+    {{modelVal}}
   </div>
+  <template v-else>
+    <el-checkbox
+      v-if="mergeConfig.selectAll && !readonly"
+      :class="'check-all'"
+      :disabled="disabled"
+      :indeterminate="isIndeterminate"
+      v-model="isCheckAll"
+      @change="handleCheckAllChange"
+    >{{$nclang('all')}}</el-checkbox>
+
+    <el-checkbox-group
+      v-if="!readonly"
+      size="mini"
+      :disabled="disabled"
+      v-model="modelVal"
+      @change="handleCheckedOptChange"
+    >
+      <component :is="'el-checkbox' + (mergeConfig.type === 'button' ? '-button' : '')"
+        v-for="opt in dataSource"
+        :key="opt[mergeConfig.itemValueField]"
+        :label="opt[mergeConfig.itemValueField]"
+        :class="mergeConfig.type === 'checkbox' && mergeConfig.arrangement === 'v' ? 'is-vertical' : ''"
+      >{{opt[mergeConfig.itemLabelField]}}</component>
+    </el-checkbox-group>
+
+    <label
+      v-show="readonly"
+      v-for="(label, idx) in labelRead"
+      :key="idx"
+      :class="['label-read', mergeConfig.type === 'checkbox' && mergeConfig.arrangement === 'v' ? 'label-vertical' : '']"
+    >{{label}}</label>
+  </template>
+</div>
 </template>
 
 <style lang="scss">

--- a/packages/ncform-theme-elementui/src/components/control-comps/checkbox.vue
+++ b/packages/ncform-theme-elementui/src/components/control-comps/checkbox.vue
@@ -1,39 +1,39 @@
 <template>
-<div
-  class="ncform-checkbox"
-  v-show="!hidden"
->
-  <el-checkbox
-    v-if="mergeConfig.selectAll && !readonly"
-    :class="'check-all'"
-    :disabled="disabled"
-    :indeterminate="isIndeterminate"
-    v-model="isCheckAll"
-    @change="handleCheckAllChange"
-  >{{$nclang('all')}}</el-checkbox>
-
-  <el-checkbox-group
-    v-if="!readonly"
-    size="mini"
-    :disabled="disabled"
-    v-model="modelVal"
-    @change="handleCheckedOptChange"
+  <div
+    class="ncform-checkbox"
+    v-show="!hidden"
   >
-    <component :is="'el-checkbox' + (mergeConfig.type === 'button' ? '-button' : '')"
-      v-for="opt in dataSource"
-      :key="opt[mergeConfig.itemValueField]"
-      :label="opt[mergeConfig.itemValueField]"
-      :class="mergeConfig.type === 'checkbox' && mergeConfig.arrangement === 'v' ? 'is-vertical' : ''"
-    >{{opt[mergeConfig.itemLabelField]}}</component>
-  </el-checkbox-group>
+    <el-checkbox
+      v-if="mergeConfig.selectAll && !readonly"
+      :class="'check-all'"
+      :disabled="disabled"
+      :indeterminate="isIndeterminate"
+      v-model="isCheckAll"
+      @change="handleCheckAllChange"
+    >{{$nclang('all')}}</el-checkbox>
 
-  <label
-    v-show="readonly"
-    v-for="(label, idx) in labelRead"
-    :key="idx"
-    :class="['label-read', mergeConfig.type === 'checkbox' && mergeConfig.arrangement === 'v' ? 'label-vertical' : '']"
-  >{{label}}</label>
-</div>
+    <el-checkbox-group
+      v-if="!readonly"
+      size="mini"
+      :disabled="disabled"
+      v-model="modelVal"
+      @change="handleCheckedOptChange"
+    >
+      <component :is="'el-checkbox' + (mergeConfig.type === 'button' ? '-button' : '')"
+        v-for="opt in dataSource"
+        :key="opt[mergeConfig.itemValueField]"
+        :label="opt[mergeConfig.itemValueField]"
+        :class="mergeConfig.type === 'checkbox' && mergeConfig.arrangement === 'v' ? 'is-vertical' : ''"
+      >{{opt[mergeConfig.itemLabelField]}}</component>
+    </el-checkbox-group>
+
+    <label
+      v-show="readonly"
+      v-for="(label, idx) in labelRead"
+      :key="idx"
+      :class="['label-read', mergeConfig.type === 'checkbox' && mergeConfig.arrangement === 'v' ? 'label-vertical' : '']"
+    >{{label}}</label>
+  </div>
 </template>
 
 <style lang="scss">

--- a/packages/ncform-theme-elementui/src/components/control-comps/checkbox.vue
+++ b/packages/ncform-theme-elementui/src/components/control-comps/checkbox.vue
@@ -1,38 +1,43 @@
 <template>
   <div
     class="ncform-checkbox"
-    :style="{display: hidden ? 'none' : ''}"
+    v-show="!hidden"
   >
-    <el-checkbox
-      v-if="mergeConfig.selectAll && !readonly"
-      :class="'check-all'"
-      :disabled="disabled"
-      :indeterminate="isIndeterminate"
-      v-model="isCheckAll"
-      @change="handleCheckAllChange"
-    >{{$nclang('all')}}</el-checkbox>
+    <div v-if="globalStatus === 'preview'" class="ncform-checkbox-preview">
+      {{modelVal}}
+    </div>
+    <template v-else>
+      <el-checkbox
+        v-if="mergeConfig.selectAll && !readonly"
+        :class="'check-all'"
+        :disabled="disabled"
+        :indeterminate="isIndeterminate"
+        v-model="isCheckAll"
+        @change="handleCheckAllChange"
+      >{{$nclang('all')}}</el-checkbox>
 
-    <el-checkbox-group
-      v-if="!readonly"
-      size="mini"
-      :disabled="disabled"
-      v-model="modelVal"
-      @change="handleCheckedOptChange"
-    >
-      <component :is="'el-checkbox' + (mergeConfig.type === 'button' ? '-button' : '')"
-        v-for="opt in dataSource"
-        :key="opt[mergeConfig.itemValueField]"
-        :label="opt[mergeConfig.itemValueField]"
-        :class="mergeConfig.type === 'checkbox' && mergeConfig.arrangement === 'v' ? 'is-vertical' : ''"
-      >{{opt[mergeConfig.itemLabelField]}}</component>
-    </el-checkbox-group>
+      <el-checkbox-group
+        v-if="!readonly"
+        size="mini"
+        :disabled="disabled"
+        v-model="modelVal"
+        @change="handleCheckedOptChange"
+      >
+        <component :is="'el-checkbox' + (mergeConfig.type === 'button' ? '-button' : '')"
+          v-for="opt in dataSource"
+          :key="opt[mergeConfig.itemValueField]"
+          :label="opt[mergeConfig.itemValueField]"
+          :class="mergeConfig.type === 'checkbox' && mergeConfig.arrangement === 'v' ? 'is-vertical' : ''"
+        >{{opt[mergeConfig.itemLabelField]}}</component>
+      </el-checkbox-group>
 
-    <label
-      v-show="readonly"
-      v-for="(label, idx) in labelRead"
-      :key="idx"
-      :class="['label-read', mergeConfig.type === 'checkbox' && mergeConfig.arrangement === 'v' ? 'label-vertical' : '']"
-    >{{label}}</label>
+      <label
+        v-show="readonly"
+        v-for="(label, idx) in labelRead"
+        :key="idx"
+        :class="['label-read', mergeConfig.type === 'checkbox' && mergeConfig.arrangement === 'v' ? 'label-vertical' : '']"
+      >{{label}}</label>
+    </template>
   </div>
 </template>
 
@@ -82,6 +87,12 @@
       &.label-vertical {
         display: block;
       }
+    }
+
+    .ncform-checkbox-preview {
+      color: #606266;
+      font-size: 14px;
+      line-height: 40px;
     }
   }
 </style>

--- a/packages/ncform-theme-elementui/src/components/control-comps/color-picker.vue
+++ b/packages/ncform-theme-elementui/src/components/control-comps/color-picker.vue
@@ -1,12 +1,29 @@
 <template>
+<div v-show="!hidden" class="ncform-color-picker">
+  <div
+    v-if="globalStatus === 'preview'"
+    class="ncform-color-picker-preview"
+    :style="{ backgroundColor: modelVal }"
+  >
+    {{modelVal}}
+  </div>
   <el-color-picker
+    v-else
     v-model="modelVal"
     :disabled="disabled || readonly"
-    v-show="!hidden"
   ></el-color-picker>
+</div>
 </template>
 
 <style lang="scss" scoped>
+  .ncform-color-picker-preview {
+    width: 6em;
+    border-radius: 4px;
+    color: #fff;
+    font-size: 14px;
+    line-height: 40px;
+    text-align: center;
+  }
 </style>
 
 <script>

--- a/packages/ncform-theme-elementui/src/components/control-comps/color-picker.vue
+++ b/packages/ncform-theme-elementui/src/components/control-comps/color-picker.vue
@@ -3,7 +3,7 @@
   <div
     v-if="globalStatus === 'preview'"
     class="ncform-color-picker-preview"
-    :style="{ backgroundColor: modelVal }"
+    :style="{ borderColor: modelVal }"
   >
     {{modelVal}}
   </div>
@@ -17,12 +17,11 @@
 
 <style lang="scss" scoped>
   .ncform-color-picker-preview {
-    width: 6em;
-    border-radius: 4px;
-    color: #fff;
+    margin: 8px 0;
+    padding: 4px 8px;
     font-size: 14px;
-    line-height: 40px;
-    text-align: center;
+    color: #606266;
+    border-left: solid 2px;
   }
 </style>
 

--- a/packages/ncform-theme-elementui/src/components/control-comps/color-picker.vue
+++ b/packages/ncform-theme-elementui/src/components/control-comps/color-picker.vue
@@ -1,18 +1,18 @@
 <template>
-<div v-show="!hidden" class="ncform-color-picker">
-  <div
-    v-if="globalStatus === 'preview'"
-    class="ncform-color-picker-preview"
-    :style="{ borderColor: modelVal }"
-  >
-    {{modelVal}}
+  <div v-show="!hidden" class="ncform-color-picker">
+    <div
+      v-if="globalStatus === 'preview'"
+      class="ncform-color-picker-preview"
+      :style="{ borderColor: modelVal }"
+    >
+      {{modelVal}}
+    </div>
+    <el-color-picker
+      v-else
+      v-model="modelVal"
+      :disabled="disabled || readonly"
+    ></el-color-picker>
   </div>
-  <el-color-picker
-    v-else
-    v-model="modelVal"
-    :disabled="disabled || readonly"
-  ></el-color-picker>
-</div>
 </template>
 
 <style lang="scss" scoped>

--- a/packages/ncform-theme-elementui/src/components/control-comps/date-picker.vue
+++ b/packages/ncform-theme-elementui/src/components/control-comps/date-picker.vue
@@ -1,18 +1,22 @@
 <template>
-  <el-date-picker class="ncform-date-picker"
-    v-if="type && typeOptions[type]"
+<div v-show="!hidden" class="ncform-date-picker">
+  <div v-if="globalStatus === 'preview'" class="ncform-date-picker-preview">
+    {{formatter(modelVal, mergeConfig.format)}}
+  </div>
+  <el-date-picker
+    v-else-if="type && typeOptions[type]"
     :placeholder="placeholder || $nclang(typeOptions[type].placeholder)"
     :disabled="disabled"
     :readonly="readonly"
     :size="mergeConfig.size"
     :clearable="mergeConfig.clearable"
-    v-show="!hidden"
     v-model="modelVal"
     :type="type"
     :format="mergeConfig.format || $nclang(typeOptions[type].format)"
     :value-format="mergeConfig.valueFormat"
     >
   </el-date-picker>
+</div>
 </template>
 
 <style lang="scss">
@@ -33,14 +37,20 @@
   }
 
   .ncform-date-picker {
-    &.el-date-editor.el-input {
+    .el-date-editor.el-input {
       width: 100%;
+    }
+    .ncform-date-picker-preview {
+      color: #606266;
+      font-size: 14px;
+      line-height: 40px;
     }
   }
 </style>
 
 <script>
 import ncformCommon from '@ncform/ncform-common';
+import { formatDate } from 'element-ui/src/utils/date-util';
 
 const controlMixin = ncformCommon.mixins.vue.controlMixin;
 
@@ -130,6 +140,10 @@ export default {
     // 你可以通过该方法在modelVal传出去之前进行加工处理，即在this.$emit('input')之前
     _processModelVal(newVal){
       return `${newVal ? (this.mergeConfig.valueFormat ? newVal : +new Date(newVal)) : ''}`;
+    },
+    formatter(value, format) {
+      if (format === 'timestamp') return value.getTime();
+      return formatDate(value, format);
     }
   }
 };

--- a/packages/ncform-theme-elementui/src/components/control-comps/date-picker.vue
+++ b/packages/ncform-theme-elementui/src/components/control-comps/date-picker.vue
@@ -1,22 +1,22 @@
 <template>
-<div v-show="!hidden" class="ncform-date-picker">
-  <div v-if="globalStatus === 'preview'" class="ncform-date-picker-preview">
-    {{formatter(modelVal, mergeConfig.format)}}
+  <div v-show="!hidden" class="ncform-date-picker">
+    <div v-if="globalStatus === 'preview'" class="ncform-date-picker-preview">
+      {{formatter(modelVal, mergeConfig.format)}}
+    </div>
+    <el-date-picker
+      v-else-if="type && typeOptions[type]"
+      :placeholder="placeholder || $nclang(typeOptions[type].placeholder)"
+      :disabled="disabled"
+      :readonly="readonly"
+      :size="mergeConfig.size"
+      :clearable="mergeConfig.clearable"
+      v-model="modelVal"
+      :type="type"
+      :format="mergeConfig.format || $nclang(typeOptions[type].format)"
+      :value-format="mergeConfig.valueFormat"
+      >
+    </el-date-picker>
   </div>
-  <el-date-picker
-    v-else-if="type && typeOptions[type]"
-    :placeholder="placeholder || $nclang(typeOptions[type].placeholder)"
-    :disabled="disabled"
-    :readonly="readonly"
-    :size="mergeConfig.size"
-    :clearable="mergeConfig.clearable"
-    v-model="modelVal"
-    :type="type"
-    :format="mergeConfig.format || $nclang(typeOptions[type].format)"
-    :value-format="mergeConfig.valueFormat"
-    >
-  </el-date-picker>
-</div>
 </template>
 
 <style lang="scss">

--- a/packages/ncform-theme-elementui/src/components/control-comps/input-number.vue
+++ b/packages/ncform-theme-elementui/src/components/control-comps/input-number.vue
@@ -4,9 +4,9 @@
       {{modelVal}}
     </div>
     <el-input-number
-      :disabled="disabled || readonly"
-      v-show="!hidden"
+      v-else
       v-model="modelVal"
+      :disabled="disabled || readonly"
       :min="mergeConfig.min"
       :max="mergeConfig.max"
       :step="mergeConfig.step"

--- a/packages/ncform-theme-elementui/src/components/control-comps/input-number.vue
+++ b/packages/ncform-theme-elementui/src/components/control-comps/input-number.vue
@@ -1,15 +1,18 @@
 <template>
-    <div class="ncform-input-number">
-        <el-input-number
-          :disabled="disabled || readonly"
-          v-show="!hidden"
-          v-model="modelVal"
-          :min="mergeConfig.min"
-          :max="mergeConfig.max"
-          :step="mergeConfig.step"
-          :size="mergeConfig.size"
-        ></el-input-number>
+  <div v-show="!hidden" class="ncform-input-number">
+    <div v-if="globalStatus === 'preview'" class="ncform-input-number-preview">
+      {{modelVal}}
     </div>
+    <el-input-number
+      :disabled="disabled || readonly"
+      v-show="!hidden"
+      v-model="modelVal"
+      :min="mergeConfig.min"
+      :max="mergeConfig.max"
+      :step="mergeConfig.step"
+      :size="mergeConfig.size"
+    ></el-input-number>
+  </div>
 </template>
 
 <style lang="scss">
@@ -27,6 +30,12 @@
         clear: both;
       }
     }
+  }
+
+  .ncform-input-number-preview {
+    color: #606266;
+    font-size: 14px;
+    line-height: 40px;
   }
 </style>
 

--- a/packages/ncform-theme-elementui/src/components/control-comps/input.vue
+++ b/packages/ncform-theme-elementui/src/components/control-comps/input.vue
@@ -1,5 +1,10 @@
 <template>
-  <div class="ncform-input">
+<div v-show="!hidden" class="ncform-input">
+  <div v-if="globalStatus === 'preview'" class="ncform-input-preview">
+    {{mergeConfig.compound && mergeConfig.compound.prependLabel}}
+    {{inputVal}}
+  </div>
+  <template v-else>
     <!-- 没有自动补全 -->
     <el-input
       v-if="!mergeConfig.autocomplete"
@@ -7,7 +12,6 @@
       :disabled="disabled"
       :readonly="readonly"
       :placeholder="placeholder"
-      v-show="!hidden"
       :clearable="mergeConfig.clearable"
       :type="mergeConfig.type === 'file' ? 'text' : mergeConfig.type"
       :prefix-icon="mergeConfig.prefixIcon"
@@ -90,7 +94,6 @@
       :disabled="disabled"
       :readonly="readonly"
       :placeholder="placeholder"
-      v-show="!hidden"
       :clearable="mergeConfig.clearable"
       :size="mergeConfig.size"
       :type="mergeConfig.type"
@@ -160,7 +163,8 @@
         </el-select>
       </template>
     </el-autocomplete>
-  </div>
+  </template>
+</div>
 </template>
 
 <style lang="scss">
@@ -178,6 +182,11 @@
   }
   .el-autocomplete {
     width: 100%;
+  }
+  .ncform-input-preview {
+    color: #606266;
+    font-size: 14px;
+    line-height: 40px;
   }
 }
 </style>

--- a/packages/ncform-theme-elementui/src/components/control-comps/input.vue
+++ b/packages/ncform-theme-elementui/src/components/control-comps/input.vue
@@ -1,164 +1,164 @@
 <template>
-<div v-show="!hidden" class="ncform-input">
-  <!-- 没有自动补全 -->
-  <el-input
-    v-if="!mergeConfig.autocomplete"
-    :size="mergeConfig.size"
-    :disabled="disabled"
-    :readonly="readonly"
-    :placeholder="placeholder"
-    :clearable="mergeConfig.clearable"
-    :type="mergeConfig.type === 'file' ? 'text' : mergeConfig.type"
-    :prefix-icon="mergeConfig.prefixIcon"
-    :suffix-icon="mergeConfig.suffixIcon"
-    @blur="onBlur"
-    v-model="inputVal"
-  >
-    <template v-if="mergeConfig.type !== 'file' && mergeConfig.compound">
-      <template
-        slot="prepend"
-        v-if="mergeConfig.compound.prependLabel"
-      >{{mergeConfig.compound.prependLabel}}</template>
-      <template
-        slot="append"
-        v-if="mergeConfig.compound.appendLabel"
-      >{{mergeConfig.compound.appendLabel}}</template>
-
-      <el-button
-        slot="prepend"
-        v-if="mergeConfig.compound.prependIcon"
-        :icon="mergeConfig.compound.prependIcon"
-      ></el-button>
-      <el-button
-        slot="append"
-        v-if="mergeConfig.compound.appendIcon"
-        :icon="mergeConfig.compound.appendIcon"
-      ></el-button>
-
-      <el-select
-        v-if="mergeConfig.compound.prependSelect"
-        v-model="prependSelectVal"
-        slot="prepend"
-        :placeholder="mergeConfig.compound.prependSelect.placeholder || $nclang('selectPls')"
-      >
-        <el-option
-          v-for="item in prependSelectOptions"
-          :label="item[mergeConfig.compound.prependSelect.itemLabelField]"
-          :value="item[mergeConfig.compound.prependSelect.itemValueField]"
-          :key="item[mergeConfig.compound.prependSelect.itemValueField]"
-        ></el-option>
-      </el-select>
-
-      <el-select
-        v-if="mergeConfig.compound.appendSelect"
-        v-model="appendSelectVal"
-        slot="append"
-        :placeholder="mergeConfig.compound.appendSelect.placeholder || $nclang('selectPls')"
-      >
-        <el-option
-          v-for="item in appendSelectOptions"
-          :label="item[mergeConfig.compound.appendSelect.itemLabelField]"
-          :value="item[mergeConfig.compound.appendSelect.itemValueField]"
-          :key="item[mergeConfig.compound.appendSelect.itemValueField]"
-        ></el-option>
-      </el-select>
-    </template>
-
-    <!--上传类型-->
-    <template v-else-if="mergeConfig.type === 'file' && mergeConfig.upload">
-      <el-button
-        slot="append"
-        v-if="mergeConfig.upload.uploadUrl"
-        class="ncform-input-upload"
-        @click="handleClickUpload"
-      >
-        {{isUploading ? $nclang('uploading') : mergeConfig.upload.uploadText || $nclang('upload')}}
-        <input
-          type="file"
-          ref="upload"
-          :accept="mergeConfig.upload.accept || ''"
-          @change="handleFileChange"
-        >
-      </el-button>
-    </template>
-  </el-input>
-
-  <!-- 自动补全 -->
-  <el-autocomplete
-    v-else
-    :disabled="disabled"
-    :readonly="readonly"
-    :placeholder="placeholder"
-    :clearable="mergeConfig.clearable"
-    :size="mergeConfig.size"
-    :type="mergeConfig.type"
-    :prefix-icon="mergeConfig.prefixIcon"
-    :suffix-icon="mergeConfig.suffixIcon"
-    :fetch-suggestions="querySearch"
-    :trigger-on-focus="!!mergeConfig.autocomplete.immediateShow"
-    :value-key="mergeConfig.autocomplete.itemValueField || 'value'"
-    v-model="inputVal"
-    @select="onSelectSuggectionItem"
-    @blur="onBlur"
-  >
-    <template
-      slot-scope="props"
-      v-if="mergeConfig.autocomplete && mergeConfig.autocomplete.itemTemplate"
+  <div v-show="!hidden" class="ncform-input">
+    <!-- 没有自动补全 -->
+    <el-input
+      v-if="!mergeConfig.autocomplete"
+      :size="mergeConfig.size"
+      :disabled="disabled"
+      :readonly="readonly"
+      :placeholder="placeholder"
+      :clearable="mergeConfig.clearable"
+      :type="mergeConfig.type === 'file' ? 'text' : mergeConfig.type"
+      :prefix-icon="mergeConfig.prefixIcon"
+      :suffix-icon="mergeConfig.suffixIcon"
+      @blur="onBlur"
+      v-model="inputVal"
     >
-      <component :is="itemTemplate" :item="props.item"></component>
-    </template>
+      <template v-if="mergeConfig.type !== 'file' && mergeConfig.compound">
+        <template
+          slot="prepend"
+          v-if="mergeConfig.compound.prependLabel"
+        >{{mergeConfig.compound.prependLabel}}</template>
+        <template
+          slot="append"
+          v-if="mergeConfig.compound.appendLabel"
+        >{{mergeConfig.compound.appendLabel}}</template>
 
-    <template v-if="mergeConfig.compound">
+        <el-button
+          slot="prepend"
+          v-if="mergeConfig.compound.prependIcon"
+          :icon="mergeConfig.compound.prependIcon"
+        ></el-button>
+        <el-button
+          slot="append"
+          v-if="mergeConfig.compound.appendIcon"
+          :icon="mergeConfig.compound.appendIcon"
+        ></el-button>
+
+        <el-select
+          v-if="mergeConfig.compound.prependSelect"
+          v-model="prependSelectVal"
+          slot="prepend"
+          :placeholder="mergeConfig.compound.prependSelect.placeholder || $nclang('selectPls')"
+        >
+          <el-option
+            v-for="item in prependSelectOptions"
+            :label="item[mergeConfig.compound.prependSelect.itemLabelField]"
+            :value="item[mergeConfig.compound.prependSelect.itemValueField]"
+            :key="item[mergeConfig.compound.prependSelect.itemValueField]"
+          ></el-option>
+        </el-select>
+
+        <el-select
+          v-if="mergeConfig.compound.appendSelect"
+          v-model="appendSelectVal"
+          slot="append"
+          :placeholder="mergeConfig.compound.appendSelect.placeholder || $nclang('selectPls')"
+        >
+          <el-option
+            v-for="item in appendSelectOptions"
+            :label="item[mergeConfig.compound.appendSelect.itemLabelField]"
+            :value="item[mergeConfig.compound.appendSelect.itemValueField]"
+            :key="item[mergeConfig.compound.appendSelect.itemValueField]"
+          ></el-option>
+        </el-select>
+      </template>
+
+      <!--上传类型-->
+      <template v-else-if="mergeConfig.type === 'file' && mergeConfig.upload">
+        <el-button
+          slot="append"
+          v-if="mergeConfig.upload.uploadUrl"
+          class="ncform-input-upload"
+          @click="handleClickUpload"
+        >
+          {{isUploading ? $nclang('uploading') : mergeConfig.upload.uploadText || $nclang('upload')}}
+          <input
+            type="file"
+            ref="upload"
+            :accept="mergeConfig.upload.accept || ''"
+            @change="handleFileChange"
+          >
+        </el-button>
+      </template>
+    </el-input>
+
+    <!-- 自动补全 -->
+    <el-autocomplete
+      v-else
+      :disabled="disabled"
+      :readonly="readonly"
+      :placeholder="placeholder"
+      :clearable="mergeConfig.clearable"
+      :size="mergeConfig.size"
+      :type="mergeConfig.type"
+      :prefix-icon="mergeConfig.prefixIcon"
+      :suffix-icon="mergeConfig.suffixIcon"
+      :fetch-suggestions="querySearch"
+      :trigger-on-focus="!!mergeConfig.autocomplete.immediateShow"
+      :value-key="mergeConfig.autocomplete.itemValueField || 'value'"
+      v-model="inputVal"
+      @select="onSelectSuggectionItem"
+      @blur="onBlur"
+    >
       <template
-        slot="prepend"
-        v-if="mergeConfig.compound.prependLabel"
-      >{{mergeConfig.compound.prependLabel}}</template>
-      <template
-        slot="append"
-        v-if="mergeConfig.compound.appendLabel"
-      >{{mergeConfig.compound.appendLabel}}</template>
-
-      <el-button
-        slot="prepend"
-        v-if="mergeConfig.compound.prependIcon"
-        :icon="mergeConfig.compound.prependIcon"
-      ></el-button>
-      <el-button
-        slot="append"
-        v-if="mergeConfig.compound.appendIcon"
-        :icon="mergeConfig.compound.appendIcon"
-      ></el-button>
-
-      <el-select
-        v-if="mergeConfig.compound.prependSelect"
-        v-model="prependSelectVal"
-        slot="prepend"
-        :placeholder="mergeConfig.compound.prependSelect.placeholder || $nclang('selectPls')"
+        slot-scope="props"
+        v-if="mergeConfig.autocomplete && mergeConfig.autocomplete.itemTemplate"
       >
-        <el-option
-          v-for="item in prependSelectOptions"
-          :label="item[mergeConfig.compound.prependSelect.itemLabelField]"
-          :value="item[mergeConfig.compound.prependSelect.itemValueField]"
-          :key="item[mergeConfig.compound.prependSelect.itemValueField]"
-        ></el-option>
-      </el-select>
+        <component :is="itemTemplate" :item="props.item"></component>
+      </template>
 
-      <el-select
-        v-if="mergeConfig.compound.appendSelect"
-        v-model="appendSelectVal"
-        slot="append"
-        :placeholder="mergeConfig.compound.appendSelect.placeholder || $nclang('selectPls')"
-      >
-        <el-option
-          v-for="item in appendSelectOptions"
-          :label="item[mergeConfig.compound.appendSelect.itemLabelField]"
-          :value="item[mergeConfig.compound.appendSelect.itemValueField]"
-          :key="item[mergeConfig.compound.appendSelectVal.itemValueField]"
-        ></el-option>
-      </el-select>
-    </template>
-  </el-autocomplete>
-</div>
+      <template v-if="mergeConfig.compound">
+        <template
+          slot="prepend"
+          v-if="mergeConfig.compound.prependLabel"
+        >{{mergeConfig.compound.prependLabel}}</template>
+        <template
+          slot="append"
+          v-if="mergeConfig.compound.appendLabel"
+        >{{mergeConfig.compound.appendLabel}}</template>
+
+        <el-button
+          slot="prepend"
+          v-if="mergeConfig.compound.prependIcon"
+          :icon="mergeConfig.compound.prependIcon"
+        ></el-button>
+        <el-button
+          slot="append"
+          v-if="mergeConfig.compound.appendIcon"
+          :icon="mergeConfig.compound.appendIcon"
+        ></el-button>
+
+        <el-select
+          v-if="mergeConfig.compound.prependSelect"
+          v-model="prependSelectVal"
+          slot="prepend"
+          :placeholder="mergeConfig.compound.prependSelect.placeholder || $nclang('selectPls')"
+        >
+          <el-option
+            v-for="item in prependSelectOptions"
+            :label="item[mergeConfig.compound.prependSelect.itemLabelField]"
+            :value="item[mergeConfig.compound.prependSelect.itemValueField]"
+            :key="item[mergeConfig.compound.prependSelect.itemValueField]"
+          ></el-option>
+        </el-select>
+
+        <el-select
+          v-if="mergeConfig.compound.appendSelect"
+          v-model="appendSelectVal"
+          slot="append"
+          :placeholder="mergeConfig.compound.appendSelect.placeholder || $nclang('selectPls')"
+        >
+          <el-option
+            v-for="item in appendSelectOptions"
+            :label="item[mergeConfig.compound.appendSelect.itemLabelField]"
+            :value="item[mergeConfig.compound.appendSelect.itemValueField]"
+            :key="item[mergeConfig.compound.appendSelectVal.itemValueField]"
+          ></el-option>
+        </el-select>
+      </template>
+    </el-autocomplete>
+  </div>
 </template>
 
 <style lang="scss">

--- a/packages/ncform-theme-elementui/src/components/control-comps/input.vue
+++ b/packages/ncform-theme-elementui/src/components/control-comps/input.vue
@@ -1,169 +1,163 @@
 <template>
 <div v-show="!hidden" class="ncform-input">
-  <div v-if="globalStatus === 'preview'" class="ncform-input-preview">
-    {{mergeConfig.compound && mergeConfig.compound.prependLabel}}
-    {{inputVal}}
-  </div>
-  <template v-else>
-    <!-- 没有自动补全 -->
-    <el-input
-      v-if="!mergeConfig.autocomplete"
-      :size="mergeConfig.size"
-      :disabled="disabled"
-      :readonly="readonly"
-      :placeholder="placeholder"
-      :clearable="mergeConfig.clearable"
-      :type="mergeConfig.type === 'file' ? 'text' : mergeConfig.type"
-      :prefix-icon="mergeConfig.prefixIcon"
-      :suffix-icon="mergeConfig.suffixIcon"
-      @blur="onBlur"
-      v-model="inputVal"
-    >
-      <template v-if="mergeConfig.type !== 'file' && mergeConfig.compound">
-        <template
-          slot="prepend"
-          v-if="mergeConfig.compound.prependLabel"
-        >{{mergeConfig.compound.prependLabel}}</template>
-        <template
-          slot="append"
-          v-if="mergeConfig.compound.appendLabel"
-        >{{mergeConfig.compound.appendLabel}}</template>
-
-        <el-button
-          slot="prepend"
-          v-if="mergeConfig.compound.prependIcon"
-          :icon="mergeConfig.compound.prependIcon"
-        ></el-button>
-        <el-button
-          slot="append"
-          v-if="mergeConfig.compound.appendIcon"
-          :icon="mergeConfig.compound.appendIcon"
-        ></el-button>
-
-        <el-select
-          v-if="mergeConfig.compound.prependSelect"
-          v-model="prependSelectVal"
-          slot="prepend"
-          :placeholder="mergeConfig.compound.prependSelect.placeholder || $nclang('selectPls')"
-        >
-          <el-option
-            v-for="item in prependSelectOptions"
-            :label="item[mergeConfig.compound.prependSelect.itemLabelField]"
-            :value="item[mergeConfig.compound.prependSelect.itemValueField]"
-            :key="item[mergeConfig.compound.prependSelect.itemValueField]"
-          ></el-option>
-        </el-select>
-
-        <el-select
-          v-if="mergeConfig.compound.appendSelect"
-          v-model="appendSelectVal"
-          slot="append"
-          :placeholder="mergeConfig.compound.appendSelect.placeholder || $nclang('selectPls')"
-        >
-          <el-option
-            v-for="item in appendSelectOptions"
-            :label="item[mergeConfig.compound.appendSelect.itemLabelField]"
-            :value="item[mergeConfig.compound.appendSelect.itemValueField]"
-            :key="item[mergeConfig.compound.appendSelect.itemValueField]"
-          ></el-option>
-        </el-select>
-      </template>
-
-      <!--上传类型-->
-      <template v-else-if="mergeConfig.type === 'file' && mergeConfig.upload">
-        <el-button
-          slot="append"
-          v-if="mergeConfig.upload.uploadUrl"
-          class="ncform-input-upload"
-          @click="handleClickUpload"
-        >
-          {{isUploading ? $nclang('uploading') : mergeConfig.upload.uploadText || $nclang('upload')}}
-          <input
-            type="file"
-            ref="upload"
-            :accept="mergeConfig.upload.accept || ''"
-            @change="handleFileChange"
-          >
-        </el-button>
-      </template>
-    </el-input>
-
-    <!-- 自动补全 -->
-    <el-autocomplete
-      v-else
-      :disabled="disabled"
-      :readonly="readonly"
-      :placeholder="placeholder"
-      :clearable="mergeConfig.clearable"
-      :size="mergeConfig.size"
-      :type="mergeConfig.type"
-      :prefix-icon="mergeConfig.prefixIcon"
-      :suffix-icon="mergeConfig.suffixIcon"
-      :fetch-suggestions="querySearch"
-      :trigger-on-focus="!!mergeConfig.autocomplete.immediateShow"
-      :value-key="mergeConfig.autocomplete.itemValueField || 'value'"
-      v-model="inputVal"
-      @select="onSelectSuggectionItem"
-      @blur="onBlur"
-    >
+  <!-- 没有自动补全 -->
+  <el-input
+    v-if="!mergeConfig.autocomplete"
+    :size="mergeConfig.size"
+    :disabled="disabled"
+    :readonly="readonly"
+    :placeholder="placeholder"
+    :clearable="mergeConfig.clearable"
+    :type="mergeConfig.type === 'file' ? 'text' : mergeConfig.type"
+    :prefix-icon="mergeConfig.prefixIcon"
+    :suffix-icon="mergeConfig.suffixIcon"
+    @blur="onBlur"
+    v-model="inputVal"
+  >
+    <template v-if="mergeConfig.type !== 'file' && mergeConfig.compound">
       <template
-        slot-scope="props"
-        v-if="mergeConfig.autocomplete && mergeConfig.autocomplete.itemTemplate"
+        slot="prepend"
+        v-if="mergeConfig.compound.prependLabel"
+      >{{mergeConfig.compound.prependLabel}}</template>
+      <template
+        slot="append"
+        v-if="mergeConfig.compound.appendLabel"
+      >{{mergeConfig.compound.appendLabel}}</template>
+
+      <el-button
+        slot="prepend"
+        v-if="mergeConfig.compound.prependIcon"
+        :icon="mergeConfig.compound.prependIcon"
+      ></el-button>
+      <el-button
+        slot="append"
+        v-if="mergeConfig.compound.appendIcon"
+        :icon="mergeConfig.compound.appendIcon"
+      ></el-button>
+
+      <el-select
+        v-if="mergeConfig.compound.prependSelect"
+        v-model="prependSelectVal"
+        slot="prepend"
+        :placeholder="mergeConfig.compound.prependSelect.placeholder || $nclang('selectPls')"
       >
-        <component :is="itemTemplate" :item="props.item"></component>
-      </template>
+        <el-option
+          v-for="item in prependSelectOptions"
+          :label="item[mergeConfig.compound.prependSelect.itemLabelField]"
+          :value="item[mergeConfig.compound.prependSelect.itemValueField]"
+          :key="item[mergeConfig.compound.prependSelect.itemValueField]"
+        ></el-option>
+      </el-select>
 
-      <template v-if="mergeConfig.compound">
-        <template
-          slot="prepend"
-          v-if="mergeConfig.compound.prependLabel"
-        >{{mergeConfig.compound.prependLabel}}</template>
-        <template
-          slot="append"
-          v-if="mergeConfig.compound.appendLabel"
-        >{{mergeConfig.compound.appendLabel}}</template>
+      <el-select
+        v-if="mergeConfig.compound.appendSelect"
+        v-model="appendSelectVal"
+        slot="append"
+        :placeholder="mergeConfig.compound.appendSelect.placeholder || $nclang('selectPls')"
+      >
+        <el-option
+          v-for="item in appendSelectOptions"
+          :label="item[mergeConfig.compound.appendSelect.itemLabelField]"
+          :value="item[mergeConfig.compound.appendSelect.itemValueField]"
+          :key="item[mergeConfig.compound.appendSelect.itemValueField]"
+        ></el-option>
+      </el-select>
+    </template>
 
-        <el-button
-          slot="prepend"
-          v-if="mergeConfig.compound.prependIcon"
-          :icon="mergeConfig.compound.prependIcon"
-        ></el-button>
-        <el-button
-          slot="append"
-          v-if="mergeConfig.compound.appendIcon"
-          :icon="mergeConfig.compound.appendIcon"
-        ></el-button>
-
-        <el-select
-          v-if="mergeConfig.compound.prependSelect"
-          v-model="prependSelectVal"
-          slot="prepend"
-          :placeholder="mergeConfig.compound.prependSelect.placeholder || $nclang('selectPls')"
+    <!--上传类型-->
+    <template v-else-if="mergeConfig.type === 'file' && mergeConfig.upload">
+      <el-button
+        slot="append"
+        v-if="mergeConfig.upload.uploadUrl"
+        class="ncform-input-upload"
+        @click="handleClickUpload"
+      >
+        {{isUploading ? $nclang('uploading') : mergeConfig.upload.uploadText || $nclang('upload')}}
+        <input
+          type="file"
+          ref="upload"
+          :accept="mergeConfig.upload.accept || ''"
+          @change="handleFileChange"
         >
-          <el-option
-            v-for="item in prependSelectOptions"
-            :label="item[mergeConfig.compound.prependSelect.itemLabelField]"
-            :value="item[mergeConfig.compound.prependSelect.itemValueField]"
-            :key="item[mergeConfig.compound.prependSelect.itemValueField]"
-          ></el-option>
-        </el-select>
+      </el-button>
+    </template>
+  </el-input>
 
-        <el-select
-          v-if="mergeConfig.compound.appendSelect"
-          v-model="appendSelectVal"
-          slot="append"
-          :placeholder="mergeConfig.compound.appendSelect.placeholder || $nclang('selectPls')"
-        >
-          <el-option
-            v-for="item in appendSelectOptions"
-            :label="item[mergeConfig.compound.appendSelect.itemLabelField]"
-            :value="item[mergeConfig.compound.appendSelect.itemValueField]"
-            :key="item[mergeConfig.compound.appendSelectVal.itemValueField]"
-          ></el-option>
-        </el-select>
-      </template>
-    </el-autocomplete>
-  </template>
+  <!-- 自动补全 -->
+  <el-autocomplete
+    v-else
+    :disabled="disabled"
+    :readonly="readonly"
+    :placeholder="placeholder"
+    :clearable="mergeConfig.clearable"
+    :size="mergeConfig.size"
+    :type="mergeConfig.type"
+    :prefix-icon="mergeConfig.prefixIcon"
+    :suffix-icon="mergeConfig.suffixIcon"
+    :fetch-suggestions="querySearch"
+    :trigger-on-focus="!!mergeConfig.autocomplete.immediateShow"
+    :value-key="mergeConfig.autocomplete.itemValueField || 'value'"
+    v-model="inputVal"
+    @select="onSelectSuggectionItem"
+    @blur="onBlur"
+  >
+    <template
+      slot-scope="props"
+      v-if="mergeConfig.autocomplete && mergeConfig.autocomplete.itemTemplate"
+    >
+      <component :is="itemTemplate" :item="props.item"></component>
+    </template>
+
+    <template v-if="mergeConfig.compound">
+      <template
+        slot="prepend"
+        v-if="mergeConfig.compound.prependLabel"
+      >{{mergeConfig.compound.prependLabel}}</template>
+      <template
+        slot="append"
+        v-if="mergeConfig.compound.appendLabel"
+      >{{mergeConfig.compound.appendLabel}}</template>
+
+      <el-button
+        slot="prepend"
+        v-if="mergeConfig.compound.prependIcon"
+        :icon="mergeConfig.compound.prependIcon"
+      ></el-button>
+      <el-button
+        slot="append"
+        v-if="mergeConfig.compound.appendIcon"
+        :icon="mergeConfig.compound.appendIcon"
+      ></el-button>
+
+      <el-select
+        v-if="mergeConfig.compound.prependSelect"
+        v-model="prependSelectVal"
+        slot="prepend"
+        :placeholder="mergeConfig.compound.prependSelect.placeholder || $nclang('selectPls')"
+      >
+        <el-option
+          v-for="item in prependSelectOptions"
+          :label="item[mergeConfig.compound.prependSelect.itemLabelField]"
+          :value="item[mergeConfig.compound.prependSelect.itemValueField]"
+          :key="item[mergeConfig.compound.prependSelect.itemValueField]"
+        ></el-option>
+      </el-select>
+
+      <el-select
+        v-if="mergeConfig.compound.appendSelect"
+        v-model="appendSelectVal"
+        slot="append"
+        :placeholder="mergeConfig.compound.appendSelect.placeholder || $nclang('selectPls')"
+      >
+        <el-option
+          v-for="item in appendSelectOptions"
+          :label="item[mergeConfig.compound.appendSelect.itemLabelField]"
+          :value="item[mergeConfig.compound.appendSelect.itemValueField]"
+          :key="item[mergeConfig.compound.appendSelectVal.itemValueField]"
+        ></el-option>
+      </el-select>
+    </template>
+  </el-autocomplete>
 </div>
 </template>
 
@@ -182,11 +176,6 @@
   }
   .el-autocomplete {
     width: 100%;
-  }
-  .ncform-input-preview {
-    color: #606266;
-    font-size: 14px;
-    line-height: 40px;
   }
 }
 </style>

--- a/packages/ncform-theme-elementui/src/components/control-comps/radio.vue
+++ b/packages/ncform-theme-elementui/src/components/control-comps/radio.vue
@@ -1,10 +1,6 @@
 <template>
 <div class="ncform-radio" v-show="!hidden && !readonly">
-  <div v-if="globalStatus === 'preview'" class="ncform-radio-preview">
-    {{modelVal}}
-  </div>
   <el-radio-group
-    v-else
     v-model="modelVal"
     :disabled="disabled"
     size="mini"
@@ -52,12 +48,6 @@
 
     .label-read {
       font-size: 14px;
-    }
-
-    .ncform-radio-preview {
-      color: #606266;
-      font-size: 14px;
-      line-height: 40px;
     }
   }
 

--- a/packages/ncform-theme-elementui/src/components/control-comps/radio.vue
+++ b/packages/ncform-theme-elementui/src/components/control-comps/radio.vue
@@ -1,20 +1,20 @@
 <template>
-<div class="ncform-radio" v-show="!hidden && !readonly">
-  <el-radio-group
-    v-model="modelVal"
-    :disabled="disabled"
-    size="mini"
-  >
-    <component :is="'el-radio' + (mergeConfig.type === 'button' ? '-button' : '')"
-      v-for="opt in dataSource"
-      :key="opt[mergeConfig.itemValueField]"
-      :label="opt[mergeConfig.itemValueField]"
-      :class="mergeConfig.type === 'radio' && mergeConfig.arrangement === 'v' ? 'is-vertical' : ''"
-    >{{opt[mergeConfig.itemLabelField]}}</component>
-  </el-radio-group>
+  <div class="ncform-radio" v-show="!hidden && !readonly">
+    <el-radio-group
+      v-model="modelVal"
+      :disabled="disabled"
+      size="mini"
+    >
+      <component :is="'el-radio' + (mergeConfig.type === 'button' ? '-button' : '')"
+        v-for="opt in dataSource"
+        :key="opt[mergeConfig.itemValueField]"
+        :label="opt[mergeConfig.itemValueField]"
+        :class="mergeConfig.type === 'radio' && mergeConfig.arrangement === 'v' ? 'is-vertical' : ''"
+      >{{opt[mergeConfig.itemLabelField]}}</component>
+    </el-radio-group>
 
-  <label v-show="readonly" class="label-read">{{labelRead}}</label>
-</div>
+    <label v-show="readonly" class="label-read">{{labelRead}}</label>
+  </div>
 </template>
 
 <style lang="scss">

--- a/packages/ncform-theme-elementui/src/components/control-comps/radio.vue
+++ b/packages/ncform-theme-elementui/src/components/control-comps/radio.vue
@@ -1,21 +1,24 @@
 <template>
-    <div class="ncform-radio">
-      <el-radio-group
-        v-model="modelVal"
-        :disabled="disabled"
-        v-show="!hidden && !readonly"
-        size="mini"
-      >
-        <component :is="'el-radio' + (mergeConfig.type === 'button' ? '-button' : '')"
-          v-for="opt in dataSource"
-          :key="opt[mergeConfig.itemValueField]"
-          :label="opt[mergeConfig.itemValueField]"
-          :class="mergeConfig.type === 'radio' && mergeConfig.arrangement === 'v' ? 'is-vertical' : ''"
-        >{{opt[mergeConfig.itemLabelField]}}</component>
-      </el-radio-group>
+<div class="ncform-radio" v-show="!hidden && !readonly">
+  <div v-if="globalStatus === 'preview'" class="ncform-radio-preview">
+    {{modelVal}}
+  </div>
+  <el-radio-group
+    v-else
+    v-model="modelVal"
+    :disabled="disabled"
+    size="mini"
+  >
+    <component :is="'el-radio' + (mergeConfig.type === 'button' ? '-button' : '')"
+      v-for="opt in dataSource"
+      :key="opt[mergeConfig.itemValueField]"
+      :label="opt[mergeConfig.itemValueField]"
+      :class="mergeConfig.type === 'radio' && mergeConfig.arrangement === 'v' ? 'is-vertical' : ''"
+    >{{opt[mergeConfig.itemLabelField]}}</component>
+  </el-radio-group>
 
-      <label v-show="readonly" class="label-read">{{labelRead}}</label>
-    </div>
+  <label v-show="readonly" class="label-read">{{labelRead}}</label>
+</div>
 </template>
 
 <style lang="scss">
@@ -49,6 +52,12 @@
 
     .label-read {
       font-size: 14px;
+    }
+
+    .ncform-radio-preview {
+      color: #606266;
+      font-size: 14px;
+      line-height: 40px;
     }
   }
 

--- a/packages/ncform-theme-elementui/src/components/control-comps/rate.vue
+++ b/packages/ncform-theme-elementui/src/components/control-comps/rate.vue
@@ -1,9 +1,13 @@
 <template>
-  <el-rate class="ncform-rate"
+<div v-show="!hidden" class="ncform-rate">
+  <div v-if="globalStatus === 'preview'" class="ncform-rate-preview">
+    {{modelVal}}
+  </div>
+  <el-rate
+    v-else
+    v-model="modelVal"
     :disabled="disabled || readonly"
     :placeholder="placeholder"
-    v-show="!hidden"
-    v-model="modelVal"
     :max="mergeConfig.max"
     :allow-half="mergeConfig.allowHalf"
     :low-threshold="mergeConfig.lowThreshold"
@@ -19,6 +23,7 @@
     :text-color="mergeConfig.textColor"
     :texts="mergeConfig.texts"
   ></el-rate>
+</div>
 </template>
 
 <style lang="scss">
@@ -38,6 +43,12 @@
         line-height: unset !important;
       }
     }
+  }
+
+  .ncform-rate-preview {
+    color: #606266;
+    font-size: 14px;
+    line-height: 40px;
   }
 </style>
 

--- a/packages/ncform-theme-elementui/src/components/control-comps/rate.vue
+++ b/packages/ncform-theme-elementui/src/components/control-comps/rate.vue
@@ -1,10 +1,6 @@
 <template>
 <div v-show="!hidden" class="ncform-rate">
-  <div v-if="globalStatus === 'preview'" class="ncform-rate-preview">
-    {{modelVal}}
-  </div>
   <el-rate
-    v-else
     v-model="modelVal"
     :disabled="disabled || readonly"
     :placeholder="placeholder"
@@ -43,12 +39,6 @@
         line-height: unset !important;
       }
     }
-  }
-
-  .ncform-rate-preview {
-    color: #606266;
-    font-size: 14px;
-    line-height: 40px;
   }
 </style>
 

--- a/packages/ncform-theme-elementui/src/components/control-comps/rate.vue
+++ b/packages/ncform-theme-elementui/src/components/control-comps/rate.vue
@@ -1,25 +1,25 @@
 <template>
-<div v-show="!hidden" class="ncform-rate">
-  <el-rate
-    v-model="modelVal"
-    :disabled="disabled || readonly"
-    :placeholder="placeholder"
-    :max="mergeConfig.max"
-    :allow-half="mergeConfig.allowHalf"
-    :low-threshold="mergeConfig.lowThreshold"
-    :high-threshold="mergeConfig.highThreshold"
-    :colors="mergeConfig.colors"
-    :void-color="mergeConfig.voidColor"
-    :disabled-void-color="mergeConfig.disabledVoidColor"
-    :icon-classes="mergeConfig.iconClasses"
-    :void-icon-class="mergeConfig.voidIconClass"
-    :disabled-void-icon-class="mergeConfig.disabledVoidIconClass"
-    :show-text="mergeConfig.showText"
-    :show-score="mergeConfig.showScore"
-    :text-color="mergeConfig.textColor"
-    :texts="mergeConfig.texts"
-  ></el-rate>
-</div>
+  <div v-show="!hidden" class="ncform-rate">
+    <el-rate
+      v-model="modelVal"
+      :disabled="disabled || readonly"
+      :placeholder="placeholder"
+      :max="mergeConfig.max"
+      :allow-half="mergeConfig.allowHalf"
+      :low-threshold="mergeConfig.lowThreshold"
+      :high-threshold="mergeConfig.highThreshold"
+      :colors="mergeConfig.colors"
+      :void-color="mergeConfig.voidColor"
+      :disabled-void-color="mergeConfig.disabledVoidColor"
+      :icon-classes="mergeConfig.iconClasses"
+      :void-icon-class="mergeConfig.voidIconClass"
+      :disabled-void-icon-class="mergeConfig.disabledVoidIconClass"
+      :show-text="mergeConfig.showText"
+      :show-score="mergeConfig.showScore"
+      :text-color="mergeConfig.textColor"
+      :texts="mergeConfig.texts"
+    ></el-rate>
+  </div>
 </template>
 
 <style lang="scss">

--- a/packages/ncform-theme-elementui/src/components/control-comps/select.vue
+++ b/packages/ncform-theme-elementui/src/components/control-comps/select.vue
@@ -1,10 +1,6 @@
 <template>
 <div v-show="!hidden" class="ncform-select">
-  <div v-if="globalStatus === 'preview'" class="ncform-select-preview">
-    {{modelVal}}
-  </div>
   <el-select
-    v-else
     v-model="modelVal"
     :placeholder="placeholder || $nclang('selectPls')"
     :disabled="disabled || readonly"
@@ -34,11 +30,6 @@
   .ncform-select {
     .el-select {
       width: 100%;
-    }
-    .ncform-select-preview {
-      color: #606266;
-      font-size: 14px;
-      line-height: 40px;
     }
   }
 </style>
@@ -112,6 +103,7 @@ export default {
         template: '',
         props: ["item"]
       },
+      selectedLabel: '',
 
       loading: false
     };

--- a/packages/ncform-theme-elementui/src/components/control-comps/select.vue
+++ b/packages/ncform-theme-elementui/src/components/control-comps/select.vue
@@ -1,8 +1,12 @@
 <template>
+<div v-show="!hidden" class="ncform-select">
+  <div v-if="globalStatus === 'preview'" class="ncform-select-preview">
+    {{modelVal}}
+  </div>
   <el-select
+    v-else
     v-model="modelVal"
     :placeholder="placeholder || $nclang('selectPls')"
-    v-show="!hidden"
     :disabled="disabled || readonly"
     :size="mergeConfig.size"
     :clearable="mergeConfig.clearable"
@@ -23,9 +27,20 @@
       <component v-if="itemTemplate.template" :item="item" :is="itemTemplate"></component>
     </el-option>
   </el-select>
+</div>
 </template>
 
 <style lang="scss" scoped>
+  .ncform-select {
+    .el-select {
+      width: 100%;
+    }
+    .ncform-select-preview {
+      color: #606266;
+      font-size: 14px;
+      line-height: 40px;
+    }
+  }
 </style>
 
 <script>

--- a/packages/ncform-theme-elementui/src/components/control-comps/select.vue
+++ b/packages/ncform-theme-elementui/src/components/control-comps/select.vue
@@ -1,29 +1,29 @@
 <template>
-<div v-show="!hidden" class="ncform-select">
-  <el-select
-    v-model="modelVal"
-    :placeholder="placeholder || $nclang('selectPls')"
-    :disabled="disabled || readonly"
-    :size="mergeConfig.size"
-    :clearable="mergeConfig.clearable"
-    :multiple="mergeConfig.multiple"
-    :filterable="mergeConfig.filterable"
-    :remote="!isLocalSource && !mergeConfig.filterLocal"
-    :remote-method="(!isLocalSource && !mergeConfig.filterLocal) ? remoteMethod : null"
-    :loading="loading"
-    @change="handleChange"
-    @visible-change="handleVisibleChange"
-  >
-    <el-option
-      v-for="item in optionsData"
-      :key="item[mergeConfig.itemValueField]"
-      :label="item[mergeConfig.itemLabelField]"
-      :value="item[mergeConfig.itemValueField]"
+  <div v-show="!hidden" class="ncform-select">
+    <el-select
+      v-model="modelVal"
+      :placeholder="placeholder || $nclang('selectPls')"
+      :disabled="disabled || readonly"
+      :size="mergeConfig.size"
+      :clearable="mergeConfig.clearable"
+      :multiple="mergeConfig.multiple"
+      :filterable="mergeConfig.filterable"
+      :remote="!isLocalSource && !mergeConfig.filterLocal"
+      :remote-method="(!isLocalSource && !mergeConfig.filterLocal) ? remoteMethod : null"
+      :loading="loading"
+      @change="handleChange"
+      @visible-change="handleVisibleChange"
     >
-      <component v-if="itemTemplate.template" :item="item" :is="itemTemplate"></component>
-    </el-option>
-  </el-select>
-</div>
+      <el-option
+        v-for="item in optionsData"
+        :key="item[mergeConfig.itemValueField]"
+        :label="item[mergeConfig.itemLabelField]"
+        :value="item[mergeConfig.itemValueField]"
+      >
+        <component v-if="itemTemplate.template" :item="item" :is="itemTemplate"></component>
+      </el-option>
+    </el-select>
+  </div>
 </template>
 
 <style lang="scss" scoped>

--- a/packages/ncform-theme-elementui/src/components/control-comps/slider.vue
+++ b/packages/ncform-theme-elementui/src/components/control-comps/slider.vue
@@ -1,10 +1,6 @@
 <template>
 <div v-show="!hidden" class="ncform-slider" style="float: left;">
-  <div v-if="globalStatus === 'preview'" class="ncform-slider-preview">
-    {{modelVal}}
-  </div>
   <el-slider
-    v-else
     v-model="modelVal"
     :disabled="disabled || readonly"
     :placeholder="placeholder"
@@ -14,14 +10,6 @@
   ></el-slider>
 </div>
 </template>
-
-<style lang="scss" scoped>
-  .ncform-slider-preview {
-    color: #606266;
-    font-size: 14px;
-    line-height: 40px;
-  }
-</style>
 
 <script>
 

--- a/packages/ncform-theme-elementui/src/components/control-comps/slider.vue
+++ b/packages/ncform-theme-elementui/src/components/control-comps/slider.vue
@@ -1,18 +1,26 @@
 <template>
-  <div style="float:left;">
-      <el-slider
-        :disabled="disabled || readonly"
-        :placeholder="placeholder"
-        v-show="!hidden"
-        v-model="modelVal"
-        :min="mergeConfig.min"
-        :max="mergeConfig.max"
-        :step="mergeConfig.step"
-      ></el-slider>
+<div v-show="!hidden" class="ncform-slider" style="float: left;">
+  <div v-if="globalStatus === 'preview'" class="ncform-slider-preview">
+    {{modelVal}}
   </div>
+  <el-slider
+    v-else
+    v-model="modelVal"
+    :disabled="disabled || readonly"
+    :placeholder="placeholder"
+    :min="mergeConfig.min"
+    :max="mergeConfig.max"
+    :step="mergeConfig.step"
+  ></el-slider>
+</div>
 </template>
 
 <style lang="scss" scoped>
+  .ncform-slider-preview {
+    color: #606266;
+    font-size: 14px;
+    line-height: 40px;
+  }
 </style>
 
 <script>

--- a/packages/ncform-theme-elementui/src/components/control-comps/slider.vue
+++ b/packages/ncform-theme-elementui/src/components/control-comps/slider.vue
@@ -1,14 +1,14 @@
 <template>
-<div v-show="!hidden" class="ncform-slider" style="float: left;">
-  <el-slider
-    v-model="modelVal"
-    :disabled="disabled || readonly"
-    :placeholder="placeholder"
-    :min="mergeConfig.min"
-    :max="mergeConfig.max"
-    :step="mergeConfig.step"
-  ></el-slider>
-</div>
+  <div v-show="!hidden" class="ncform-slider" style="float: left;">
+    <el-slider
+      v-model="modelVal"
+      :disabled="disabled || readonly"
+      :placeholder="placeholder"
+      :min="mergeConfig.min"
+      :max="mergeConfig.max"
+      :step="mergeConfig.step"
+    ></el-slider>
+  </div>
 </template>
 
 <script>

--- a/packages/ncform-theme-elementui/src/components/control-comps/switch.vue
+++ b/packages/ncform-theme-elementui/src/components/control-comps/switch.vue
@@ -1,6 +1,10 @@
 <template>
+<div v-show="!hidden" class="ncform-switch">
+  <div v-if="globalStatus === 'preview'" class="ncform-switch-preview">
+    {{modelVal}}
+  </div>
   <el-switch
-    class="ncform-switch"
+    v-else
     v-model="modelVal"
     :disabled="disabled || readonly"
     :width="mergeConfig.width"
@@ -12,8 +16,8 @@
     :inactive-value="mergeConfig.inactiveValue"
     :active-color="mergeConfig.activeColor"
     :inactive-color="mergeConfig.inactiveColor"
-    v-show="!hidden"
   ></el-switch>
+</div>
 </template>
 
 <style lang="scss">
@@ -26,6 +30,11 @@
     .__ncform-control.ncform-switch {
       line-height: unset !important;
     }
+  }
+  .ncform-switch-preview {
+    color: #606266;
+    font-size: 14px;
+    line-height: 40px;
   }
 </style>
 

--- a/packages/ncform-theme-elementui/src/components/control-comps/switch.vue
+++ b/packages/ncform-theme-elementui/src/components/control-comps/switch.vue
@@ -1,10 +1,6 @@
 <template>
 <div v-show="!hidden" class="ncform-switch">
-  <div v-if="globalStatus === 'preview'" class="ncform-switch-preview">
-    {{modelVal}}
-  </div>
   <el-switch
-    v-else
     v-model="modelVal"
     :disabled="disabled || readonly"
     :width="mergeConfig.width"
@@ -30,11 +26,6 @@
     .__ncform-control.ncform-switch {
       line-height: unset !important;
     }
-  }
-  .ncform-switch-preview {
-    color: #606266;
-    font-size: 14px;
-    line-height: 40px;
   }
 </style>
 

--- a/packages/ncform-theme-elementui/src/components/control-comps/switch.vue
+++ b/packages/ncform-theme-elementui/src/components/control-comps/switch.vue
@@ -1,19 +1,19 @@
 <template>
-<div v-show="!hidden" class="ncform-switch">
-  <el-switch
-    v-model="modelVal"
-    :disabled="disabled || readonly"
-    :width="mergeConfig.width"
-    :active-icon-class="mergeConfig.activeIconClass"
-    :inactive-icon-class="mergeConfig.inactiveIconClass"
-    :active-text="mergeConfig.activeText"
-    :inactive-text="mergeConfig.inactiveText"
-    :active-value="mergeConfig.activeValue"
-    :inactive-value="mergeConfig.inactiveValue"
-    :active-color="mergeConfig.activeColor"
-    :inactive-color="mergeConfig.inactiveColor"
-  ></el-switch>
-</div>
+  <div v-show="!hidden" class="ncform-switch">
+    <el-switch
+      v-model="modelVal"
+      :disabled="disabled || readonly"
+      :width="mergeConfig.width"
+      :active-icon-class="mergeConfig.activeIconClass"
+      :inactive-icon-class="mergeConfig.inactiveIconClass"
+      :active-text="mergeConfig.activeText"
+      :inactive-text="mergeConfig.inactiveText"
+      :active-value="mergeConfig.activeValue"
+      :inactive-value="mergeConfig.inactiveValue"
+      :active-color="mergeConfig.activeColor"
+      :inactive-color="mergeConfig.inactiveColor"
+    ></el-switch>
+  </div>
 </template>
 
 <style lang="scss">

--- a/packages/ncform-theme-elementui/src/components/control-comps/textarea.vue
+++ b/packages/ncform-theme-elementui/src/components/control-comps/textarea.vue
@@ -1,19 +1,19 @@
 <template>
-<div v-show="!hidden" class="ncform-textarea">
-  <pre v-if="globalStatus === 'preview'" class="ncform-textarea-preview">{{inputVal}}</pre>
-  <el-input
-    v-else
-    v-show="!hidden"
-    v-model="inputVal"
-    type="textarea"
-    :disabled="disabled"
-    :readonly="readonly"
-    :placeholder="placeholder"
-    :rows="mergeConfig.rows"
-    :autosize="mergeConfig.autoSize"
-    @blur="onBlur"
-  ></el-input>
-</div>
+  <div v-show="!hidden" class="ncform-textarea">
+    <pre v-if="globalStatus === 'preview'" class="ncform-textarea-preview">{{inputVal}}</pre>
+    <el-input
+      v-else
+      v-show="!hidden"
+      v-model="inputVal"
+      type="textarea"
+      :disabled="disabled"
+      :readonly="readonly"
+      :placeholder="placeholder"
+      :rows="mergeConfig.rows"
+      :autosize="mergeConfig.autoSize"
+      @blur="onBlur"
+    ></el-input>
+  </div>
 </template>
 
 <style lang="scss" scoped>

--- a/packages/ncform-theme-elementui/src/components/control-comps/textarea.vue
+++ b/packages/ncform-theme-elementui/src/components/control-comps/textarea.vue
@@ -1,18 +1,28 @@
 <template>
+<div v-show="!hidden" class="ncform-textarea">
+  <pre v-if="globalStatus === 'preview'" class="ncform-textarea-preview">{{inputVal}}</pre>
   <el-input
+    v-else
+    v-show="!hidden"
+    v-model="inputVal"
+    type="textarea"
     :disabled="disabled"
     :readonly="readonly"
-    v-show="!hidden"
     :placeholder="placeholder"
-    type="textarea"
-    v-model="inputVal"
     :rows="mergeConfig.rows"
     :autosize="mergeConfig.autoSize"
     @blur="onBlur"
   ></el-input>
+</div>
 </template>
 
 <style lang="scss" scoped>
+  .ncform-textarea-preview {
+    color: #606266;
+    font-size: 14px;
+    line-height: 1.5;
+    margin: 0;
+  }
 </style>
 
 <script>

--- a/packages/ncform-theme-elementui/src/components/control-comps/upload.vue
+++ b/packages/ncform-theme-elementui/src/components/control-comps/upload.vue
@@ -1,7 +1,39 @@
 <template>
 <div v-show="!hidden" class="ncform-upload">
   <div v-if="globalStatus === 'preview'" class="ncform-upload-preview">
-    {{fileList}}
+    <transition-group
+      tag="ul"
+      :class="[
+        'el-upload-list',
+        'el-upload-list--' + mergeConfig.listType,
+      ]"
+      name="el-list"
+    >
+      <li
+        v-for="(file, index) in modelVal"
+        :class="['el-upload-list__item', 'is-' + file.status, focusing ? 'focusing' : '']"
+        :key="index"
+        tabindex="0"
+      >
+        <slot :file="file">
+          <img
+            class="el-upload-list__item-thumbnail"
+            v-if="file.status !== 'uploading' && ['picture-card', 'picture'].indexOf(mergeConfig.listType) > -1"
+            :src="file.url" alt=""
+          >
+          <a class="el-upload-list__item-name">
+            <i class="el-icon-document"></i>{{file.name}}
+          </a>
+          <label class="el-upload-list__item-status-label">
+            <i :class="{
+              'el-icon-upload-success': true,
+              'el-icon-circle-check': mergeConfig.listType === 'text',
+              'el-icon-check': ['picture-card', 'picture'].indexOf(mergeConfig.listType) > -1
+            }"></i>
+          </label>
+        </slot>
+      </li>
+    </transition-group>
   </div>
   <el-upload
     v-else
@@ -111,12 +143,6 @@
       .el-upload {
         display: none;
       }
-    }
-
-    .ncform-upload-preview {
-      color: #606266;
-      font-size: 14px;
-      line-height: 40px;
     }
   }
 </style>

--- a/packages/ncform-theme-elementui/src/components/control-comps/upload.vue
+++ b/packages/ncform-theme-elementui/src/components/control-comps/upload.vue
@@ -1,9 +1,13 @@
 <template>
+<div v-show="!hidden" class="ncform-upload">
+  <div v-if="globalStatus === 'preview'" class="ncform-upload-preview">
+    {{fileList}}
+  </div>
   <el-upload
+    v-else
     ref="upload"
-    :class="['ncform-upload', readonly ? 'is-read-only' : '']"
+    :class="[readonly ? 'is-read-only' : '']"
     :disabled="readonly || disabled"
-    :style="{display: hidden ? 'none' : ''}"
     :action="mergeConfig.uploadUrl"
     :multiple="mergeConfig.multiple"
     :data="mergeConfig.data"
@@ -65,6 +69,7 @@
     </template>
 
   </el-upload>
+</div>
 </template>
 
 <style lang="scss">
@@ -106,6 +111,12 @@
       .el-upload {
         display: none;
       }
+    }
+
+    .ncform-upload-preview {
+      color: #606266;
+      font-size: 14px;
+      line-height: 40px;
     }
   }
 </style>

--- a/packages/ncform-theme-elementui/src/components/control-comps/upload.vue
+++ b/packages/ncform-theme-elementui/src/components/control-comps/upload.vue
@@ -1,107 +1,107 @@
 <template>
-<div v-show="!hidden" class="ncform-upload">
-  <div v-if="globalStatus === 'preview'" class="ncform-upload-preview">
-    <transition-group
-      tag="ul"
-      :class="[
-        'el-upload-list',
-        'el-upload-list--' + mergeConfig.listType,
-      ]"
-      name="el-list"
-    >
-      <li
-        v-for="(file, index) in modelVal"
-        :class="['el-upload-list__item', 'is-' + file.status, focusing ? 'focusing' : '']"
-        :key="index"
-        tabindex="0"
+  <div v-show="!hidden" class="ncform-upload">
+    <div v-if="globalStatus === 'preview'" class="ncform-upload-preview">
+      <transition-group
+        tag="ul"
+        :class="[
+          'el-upload-list',
+          'el-upload-list--' + mergeConfig.listType,
+        ]"
+        name="el-list"
       >
-        <slot :file="file">
-          <img
-            class="el-upload-list__item-thumbnail"
-            v-if="file.status !== 'uploading' && ['picture-card', 'picture'].indexOf(mergeConfig.listType) > -1"
-            :src="file.url" alt=""
-          >
-          <a class="el-upload-list__item-name">
-            <i class="el-icon-document"></i>{{file.name}}
-          </a>
-          <label class="el-upload-list__item-status-label">
-            <i :class="{
-              'el-icon-upload-success': true,
-              'el-icon-circle-check': mergeConfig.listType === 'text',
-              'el-icon-check': ['picture-card', 'picture'].indexOf(mergeConfig.listType) > -1
-            }"></i>
-          </label>
-        </slot>
-      </li>
-    </transition-group>
-  </div>
-  <el-upload
-    v-else
-    ref="upload"
-    :class="[readonly ? 'is-read-only' : '']"
-    :disabled="readonly || disabled"
-    :action="mergeConfig.uploadUrl"
-    :multiple="mergeConfig.multiple"
-    :data="mergeConfig.data"
-    :show-file-list="showFileList"
-    :drag="mergeConfig.drag"
-    :accept="mergeConfig.accept"
-    :list-type="mergeConfig.listType"
-    :auto-upload="mergeConfig.autoUpload"
-    :limit="mergeConfig.limit"
-    :on-change="handleUploadChange"
-    :on-success="handleUploadSucess"
-    :on-error="handleUploadError"
-    :on-exceed="handleUploadExceed"
-    :on-remove="handleUploadRemove"
-    :file-list="fileList"
-    :name="mergeConfig.fileField"
-    :headers="mergeConfig.headers"
-  >
-    <!-- 1. 可拖拽 -->
-    <template v-if="!readonly && mergeConfig.drag" slot="trigger">
-      <i class="el-icon-upload"></i>
-      <div class="el-upload__text" v-html="$nclang('uploadTips')"></div>
-    </template>
-    <div v-if="mergeConfig.drag && disabled" class="disabled-mask"></div>
+        <li
+          v-for="(file, index) in modelVal"
+          :class="['el-upload-list__item', 'is-' + file.status, focusing ? 'focusing' : '']"
+          :key="index"
+          tabindex="0"
+        >
+          <slot :file="file">
+            <img
+              class="el-upload-list__item-thumbnail"
+              v-if="file.status !== 'uploading' && ['picture-card', 'picture'].indexOf(mergeConfig.listType) > -1"
+              :src="file.url" alt=""
+            >
+            <a class="el-upload-list__item-name">
+              <i class="el-icon-document"></i>{{file.name}}
+            </a>
+            <label class="el-upload-list__item-status-label">
+              <i :class="{
+                'el-icon-upload-success': true,
+                'el-icon-circle-check': mergeConfig.listType === 'text',
+                'el-icon-check': ['picture-card', 'picture'].indexOf(mergeConfig.listType) > -1
+              }"></i>
+            </label>
+          </slot>
+        </li>
+      </transition-group>
+    </div>
+    <el-upload
+      v-else
+      ref="upload"
+      :class="[readonly ? 'is-read-only' : '']"
+      :disabled="readonly || disabled"
+      :action="mergeConfig.uploadUrl"
+      :multiple="mergeConfig.multiple"
+      :data="mergeConfig.data"
+      :show-file-list="showFileList"
+      :drag="mergeConfig.drag"
+      :accept="mergeConfig.accept"
+      :list-type="mergeConfig.listType"
+      :auto-upload="mergeConfig.autoUpload"
+      :limit="mergeConfig.limit"
+      :on-change="handleUploadChange"
+      :on-success="handleUploadSucess"
+      :on-error="handleUploadError"
+      :on-exceed="handleUploadExceed"
+      :on-remove="handleUploadRemove"
+      :file-list="fileList"
+      :name="mergeConfig.fileField"
+      :headers="mergeConfig.headers"
+    >
+      <!-- 1. 可拖拽 -->
+      <template v-if="!readonly && mergeConfig.drag" slot="trigger">
+        <i class="el-icon-upload"></i>
+        <div class="el-upload__text" v-html="$nclang('uploadTips')"></div>
+      </template>
+      <div v-if="mergeConfig.drag && disabled" class="disabled-mask"></div>
 
-    <!-- 2 可拖拽，非自动上传 -->
-    <el-button
-      v-if="!readonly && mergeConfig.drag && !mergeConfig.autoUpload"
-      :disabled="disabled"
-      class="upload-btn"
-      size="small"
-      type="success"
-      @click="submitUpload"
-    >{{$nclang('uploadServer')}}</el-button>
-
-    <!-- 3. 不可拖拽，自动上传-->
-    <el-button
-      v-if="!readonly && !mergeConfig.drag && mergeConfig.autoUpload"
-      :disabled="disabled"
-      size="small"
-      type="primary"
-    >{{$nclang('upload')}}</el-button>
-
-    <!-- 4. 不可拖拽，非自动上传 -->
-    <template v-if="!readonly && !mergeConfig.drag && !mergeConfig.autoUpload">
+      <!-- 2 可拖拽，非自动上传 -->
       <el-button
-        :disabled="disabled"
-        slot="trigger"
-        size="small"
-        type="primary"
-      >{{$nclang('chFile')}}</el-button>
-      <el-button
+        v-if="!readonly && mergeConfig.drag && !mergeConfig.autoUpload"
         :disabled="disabled"
         class="upload-btn"
         size="small"
         type="success"
         @click="submitUpload"
       >{{$nclang('uploadServer')}}</el-button>
-    </template>
 
-  </el-upload>
-</div>
+      <!-- 3. 不可拖拽，自动上传-->
+      <el-button
+        v-if="!readonly && !mergeConfig.drag && mergeConfig.autoUpload"
+        :disabled="disabled"
+        size="small"
+        type="primary"
+      >{{$nclang('upload')}}</el-button>
+
+      <!-- 4. 不可拖拽，非自动上传 -->
+      <template v-if="!readonly && !mergeConfig.drag && !mergeConfig.autoUpload">
+        <el-button
+          :disabled="disabled"
+          slot="trigger"
+          size="small"
+          type="primary"
+        >{{$nclang('chFile')}}</el-button>
+        <el-button
+          :disabled="disabled"
+          class="upload-btn"
+          size="small"
+          type="success"
+          @click="submitUpload"
+        >{{$nclang('uploadServer')}}</el-button>
+      </template>
+
+    </el-upload>
+  </div>
 </template>
 
 <style lang="scss">

--- a/packages/ncform-theme-elementui/src/components/layout-comps/array-table.vue
+++ b/packages/ncform-theme-elementui/src/components/layout-comps/array-table.vue
@@ -13,7 +13,7 @@
       </colgroup>
       <colgroup v-else>
         <col v-for="(renderSchema, idx) in renderSchemas" :key="idx" v-show="!analyzeItemVal(renderSchema.ui.hidden, idx)"/>
-        <col v-if="showActionColumn" width="130px"/>
+        <col v-if="globalStatus !== 'preview' && showActionColumn" width="130px"/>
       </colgroup>
       <thead>
           <th v-for="(renderSchema, idx) in renderSchemas" :key="renderSchema.ui.label" v-show="!analyzeItemVal(renderSchema.ui.hidden, idx)">
@@ -33,7 +33,7 @@
             </small>
           </th>
 
-          <th v-if="showActionColumn">{{$nclang('action')}}</th>
+          <th v-if="globalStatus !== 'preview' && showActionColumn">{{$nclang('action')}}</th>
       </thead>
       <tbody>
         <tr v-for="(dataItem, idx) in schema.value" :key="dataItem.__dataSchema.__id">
@@ -41,7 +41,7 @@
             <slot :name="fieldName" :schema="fieldSchema" :idx="idx"></slot>
           </td>
 
-          <td v-if="showActionColumn">
+          <td v-if="globalStatus !== 'preview' && showActionColumn">
             <!-- 项控制按钮 -->
             <div class="el-button-group">
               <button @click="delItem(idx, mergeConfig.requiredDelConfirm, mergeConfig.delConfirmText.item || $nclang('delItemTips'))" v-if="(!mergeConfig.disableDel && !isDelExceptionRow(dataItem.__dataSchema)) || (mergeConfig.disableDel && isDelExceptionRow(dataItem.__dataSchema))" :disabled="disabled" type="button" class="el-button el-button--danger el-button--mini"><i class="el-icon-remove"></i></button>
@@ -51,7 +51,7 @@
           </td>
         </tr>
       </tbody>
-      <tfoot v-if="!mergeConfig.disableDel || !mergeConfig.disableAdd">
+      <tfoot v-if="globalStatus !== 'preview' && (!mergeConfig.disableDel || !mergeConfig.disableAdd)">
         <tr>
           <td :colspan="renderSchemas.length + 1">
             <!-- 列表控制按钮 -->

--- a/packages/ncform-theme-elementui/src/components/layout-comps/array-table.vue
+++ b/packages/ncform-theme-elementui/src/components/layout-comps/array-table.vue
@@ -44,9 +44,9 @@
           <td v-if="showActionColumn">
             <!-- 项控制按钮 -->
             <div class="el-button-group">
-              <button @click="delItem(idx, mergeConfig.requiredDelConfirm, mergeConfig.delConfirmText.item || $nclang('delItemTips'))" v-if="(!mergeConfig.disableDel && !isDelExceptionRow(dataItem.__dataSchema)) || (mergeConfig.disableDel && isDelExceptionRow(dataItem.__dataSchema))" type="button" class="el-button el-button--danger el-button--mini"><i class="el-icon-remove"></i></button>
-              <button @click="itemUp(idx)" v-show="idx !== 0" v-if="!mergeConfig.disableReorder" type="button" class="el-button el-button--mini"><i class="el-icon-sort-up"></i></button>
-              <button @click="itemDown(idx)" v-show="idx !== schema.value.length - 1" v-if="!mergeConfig.disableReorder" type="button" class="el-button el-button--mini"><i class="el-icon-sort-down"></i></button>
+              <button @click="delItem(idx, mergeConfig.requiredDelConfirm, mergeConfig.delConfirmText.item || $nclang('delItemTips'))" v-if="(!mergeConfig.disableDel && !isDelExceptionRow(dataItem.__dataSchema)) || (mergeConfig.disableDel && isDelExceptionRow(dataItem.__dataSchema))" :disabled="disabled" type="button" class="el-button el-button--danger el-button--mini"><i class="el-icon-remove"></i></button>
+              <button @click="itemUp(idx)" v-show="idx !== 0" v-if="!mergeConfig.disableReorder" :disabled="disabled" type="button" class="el-button el-button--mini"><i class="el-icon-sort-up"></i></button>
+              <button @click="itemDown(idx)" v-show="idx !== schema.value.length - 1" v-if="!mergeConfig.disableReorder" :disabled="disabled" type="button" class="el-button el-button--mini"><i class="el-icon-sort-down"></i></button>
             </div>
           </td>
         </tr>
@@ -56,8 +56,8 @@
           <td :colspan="renderSchemas.length + 1">
             <!-- 列表控制按钮 -->
             <div class="el-button-group" v-if="!mergeConfig.disableAdd || !mergeConfig.disableDel">
-              <button @click="addItem()" v-if="!mergeConfig.disableAdd" type="button" class="el-button el-button--mini"><i class="el-icon-circle-plus-outline"></i> {{mergeConfig.addTxt || $nclang('add')}}</button>
-              <button @click="delAllItems(mergeConfig.requiredDelConfirm, mergeConfig.delConfirmText.all || $nclang('delAllTips'))" v-if="!mergeConfig.disableDel" type="button" class="el-button el-button--danger el-button--mini"><i class="el-icon-remove"></i> {{mergeConfig.delAllTxt || $nclang('delAll')}}</button>
+              <button @click="addItem()" v-if="!mergeConfig.disableAdd" :disabled="disabled" type="button" class="el-button el-button--mini"><i class="el-icon-circle-plus-outline"></i> {{mergeConfig.addTxt || $nclang('add')}}</button>
+              <button @click="delAllItems(mergeConfig.requiredDelConfirm, mergeConfig.delConfirmText.all || $nclang('delAllTips'))" v-if="!mergeConfig.disableDel" :disabled="disabled" type="button" class="el-button el-button--danger el-button--mini"><i class="el-icon-remove"></i> {{mergeConfig.delAllTxt || $nclang('delAll')}}</button>
             </div>
           </td>
         </tr>

--- a/packages/ncform-theme-elementui/src/components/layout-comps/array-tabs.vue
+++ b/packages/ncform-theme-elementui/src/components/layout-comps/array-tabs.vue
@@ -7,8 +7,8 @@
       <i v-if="!mergeConfig.disableCollapse" class="el-collapse-item__arrow" :class="{'el-icon-arrow-up': !collapsed, 'el-icon-arrow-down': collapsed}"></i>
     </legend>
 
-    <el-tabs v-show="!collapsed" :addable="!mergeConfig.disableAdd" type="card" :tab-position="mergeConfig.tabPosition" @edit="handleTabsEdit" v-model="activeName">
-      <el-tab-pane v-for="(dataItem, idx) in schema.value" :key="dataItem.__dataSchema.__id" :closable="(!mergeConfig.disableDel && !isDelExceptionRow(dataItem.__dataSchema)) || (mergeConfig.disableDel && isDelExceptionRow(dataItem.__dataSchema))" :name="'' + idx">
+    <el-tabs v-show="!collapsed" :addable="!disabled && !mergeConfig.disableAdd" type="card" :tab-position="mergeConfig.tabPosition" @edit="handleTabsEdit" v-model="activeName">
+      <el-tab-pane v-for="(dataItem, idx) in schema.value" :key="dataItem.__dataSchema.__id" :closable="!disabled && (!mergeConfig.disableDel && !isDelExceptionRow(dataItem.__dataSchema)) || (mergeConfig.disableDel && isDelExceptionRow(dataItem.__dataSchema))" :name="'' + idx">
 
         <span slot="label">
           {{_analyzeVal(dataItem.__dataSchema.ui.label) + ' ' + (idx + 1)}}

--- a/packages/ncform-theme-elementui/src/components/layout-comps/array-tabs.vue
+++ b/packages/ncform-theme-elementui/src/components/layout-comps/array-tabs.vue
@@ -7,8 +7,8 @@
       <i v-if="!mergeConfig.disableCollapse" class="el-collapse-item__arrow" :class="{'el-icon-arrow-up': !collapsed, 'el-icon-arrow-down': collapsed}"></i>
     </legend>
 
-    <el-tabs v-show="!collapsed" :addable="!disabled && !mergeConfig.disableAdd" type="card" :tab-position="mergeConfig.tabPosition" @edit="handleTabsEdit" v-model="activeName">
-      <el-tab-pane v-for="(dataItem, idx) in schema.value" :key="dataItem.__dataSchema.__id" :closable="!disabled && (!mergeConfig.disableDel && !isDelExceptionRow(dataItem.__dataSchema)) || (mergeConfig.disableDel && isDelExceptionRow(dataItem.__dataSchema))" :name="'' + idx">
+    <el-tabs v-show="!collapsed" :addable="globalStatus !== 'preview' && !disabled && !mergeConfig.disableAdd" type="card" :tab-position="mergeConfig.tabPosition" @edit="handleTabsEdit" v-model="activeName">
+      <el-tab-pane v-for="(dataItem, idx) in schema.value" :key="dataItem.__dataSchema.__id" :closable="globalStatus !== 'preview' && !disabled && (!mergeConfig.disableDel && !isDelExceptionRow(dataItem.__dataSchema)) || (mergeConfig.disableDel && isDelExceptionRow(dataItem.__dataSchema))" :name="'' + idx">
 
         <span slot="label">
           {{_analyzeVal(dataItem.__dataSchema.ui.label) + ' ' + (idx + 1)}}

--- a/packages/ncform-theme-elementui/src/components/layout-comps/array.vue
+++ b/packages/ncform-theme-elementui/src/components/layout-comps/array.vue
@@ -16,9 +16,11 @@
         <div class="el-button-group">
           <button @click="collapseItem(dataItem.__dataSchema)" v-show="dataItem.__dataSchema._expand" v-if="!mergeConfig.disableItemCollapse" :disabled="disabled" type="button" class="el-button el-button--mini"><i class="el-icon-arrow-down"></i></button>
           <button @click="collapseItem(dataItem.__dataSchema)" v-show="!dataItem.__dataSchema._expand" v-if="!mergeConfig.disableItemCollapse" :disabled="disabled" type="button" class="el-button el-button--mini"><i class="el-icon-arrow-up"></i></button>
-          <button @click="delItem(idx, mergeConfig.requiredDelConfirm, mergeConfig.delConfirmText.item || $nclang('delItemTips'))" v-if="(!mergeConfig.disableDel && !isDelExceptionRow(dataItem.__dataSchema)) || (mergeConfig.disableDel && isDelExceptionRow(dataItem.__dataSchema))" :disabled="disabled" type="button" class="el-button el-button--danger el-button--mini"><i class="el-icon-remove"></i></button>
-          <button @click="itemUp(idx)" v-show="idx !== 0" v-if="!mergeConfig.disableReorder" :disabled="disabled" type="button" class="el-button el-button--mini"><i class="el-icon-sort-up"></i></button>
-          <button @click="itemDown(idx)" v-show="idx !== schema.value.length - 1" v-if="!mergeConfig.disableReorder" :disabled="disabled" type="button" class="el-button el-button--mini"><i class="el-icon-sort-down"></i></button>
+          <template v-if="globalStatus !== 'preview'">
+            <button @click="delItem(idx, mergeConfig.requiredDelConfirm, mergeConfig.delConfirmText.item || $nclang('delItemTips'))" v-if="(!mergeConfig.disableDel && !isDelExceptionRow(dataItem.__dataSchema)) || (mergeConfig.disableDel && isDelExceptionRow(dataItem.__dataSchema))" :disabled="disabled" type="button" class="el-button el-button--danger el-button--mini"><i class="el-icon-remove"></i></button>
+            <button @click="itemUp(idx)" v-show="idx !== 0" v-if="!mergeConfig.disableReorder" :disabled="disabled" type="button" class="el-button el-button--mini"><i class="el-icon-sort-up"></i></button>
+            <button @click="itemDown(idx)" v-show="idx !== schema.value.length - 1" v-if="!mergeConfig.disableReorder" :disabled="disabled" type="button" class="el-button el-button--mini"><i class="el-icon-sort-down"></i></button>
+          </template>
         </div>
       </div>
 
@@ -43,7 +45,7 @@
     </div>
 
     <!-- 列表控制按钮 -->
-    <div v-show="!collapsed" class="el-button-group" v-if="!mergeConfig.disableAdd || !mergeConfig.disableDel">
+    <div v-show="!collapsed" class="el-button-group" v-if="globalStatus !== 'preview' && (!mergeConfig.disableAdd || !mergeConfig.disableDel)">
       <button @click="addItem()" v-if="!mergeConfig.disableAdd" :disabled="disabled" type="button" class="el-button el-button--mini"><i class="el-icon-circle-plus-outline"></i> {{mergeConfig.addTxt || $nclang('add')}}</button>
       <button @click="delAllItems(mergeConfig.requiredDelConfirm, mergeConfig.delConfirmText.all || $nclang('delAllTips'))" v-if="!mergeConfig.disableDel" :disabled="disabled" type="button" class="el-button el-button--danger el-button--mini"><i class="el-icon-remove"></i> {{mergeConfig.delAllTxt || $nclang('delAll')}}</button>
     </div>

--- a/packages/ncform-theme-elementui/src/components/layout-comps/array.vue
+++ b/packages/ncform-theme-elementui/src/components/layout-comps/array.vue
@@ -14,11 +14,11 @@
 
         <!-- 项控制按钮 -->
         <div class="el-button-group">
-          <button @click="collapseItem(dataItem.__dataSchema)" v-show="dataItem.__dataSchema._expand" v-if="!mergeConfig.disableItemCollapse" type="button" class="el-button el-button--mini"><i class="el-icon-arrow-down"></i></button>
-          <button @click="collapseItem(dataItem.__dataSchema)" v-show="!dataItem.__dataSchema._expand" v-if="!mergeConfig.disableItemCollapse" type="button" class="el-button el-button--mini"><i class="el-icon-arrow-up"></i></button>
-          <button @click="delItem(idx, mergeConfig.requiredDelConfirm, mergeConfig.delConfirmText.item || $nclang('delItemTips'))" v-if="(!mergeConfig.disableDel && !isDelExceptionRow(dataItem.__dataSchema)) || (mergeConfig.disableDel && isDelExceptionRow(dataItem.__dataSchema))" type="button" class="el-button el-button--danger el-button--mini"><i class="el-icon-remove"></i></button>
-          <button @click="itemUp(idx)" v-show="idx !== 0" v-if="!mergeConfig.disableReorder" type="button" class="el-button el-button--mini"><i class="el-icon-sort-up"></i></button>
-          <button @click="itemDown(idx)" v-show="idx !== schema.value.length - 1" v-if="!mergeConfig.disableReorder" type="button" class="el-button el-button--mini"><i class="el-icon-sort-down"></i></button>
+          <button @click="collapseItem(dataItem.__dataSchema)" v-show="dataItem.__dataSchema._expand" v-if="!mergeConfig.disableItemCollapse" :disabled="disabled" type="button" class="el-button el-button--mini"><i class="el-icon-arrow-down"></i></button>
+          <button @click="collapseItem(dataItem.__dataSchema)" v-show="!dataItem.__dataSchema._expand" v-if="!mergeConfig.disableItemCollapse" :disabled="disabled" type="button" class="el-button el-button--mini"><i class="el-icon-arrow-up"></i></button>
+          <button @click="delItem(idx, mergeConfig.requiredDelConfirm, mergeConfig.delConfirmText.item || $nclang('delItemTips'))" v-if="(!mergeConfig.disableDel && !isDelExceptionRow(dataItem.__dataSchema)) || (mergeConfig.disableDel && isDelExceptionRow(dataItem.__dataSchema))" :disabled="disabled" type="button" class="el-button el-button--danger el-button--mini"><i class="el-icon-remove"></i></button>
+          <button @click="itemUp(idx)" v-show="idx !== 0" v-if="!mergeConfig.disableReorder" :disabled="disabled" type="button" class="el-button el-button--mini"><i class="el-icon-sort-up"></i></button>
+          <button @click="itemDown(idx)" v-show="idx !== schema.value.length - 1" v-if="!mergeConfig.disableReorder" :disabled="disabled" type="button" class="el-button el-button--mini"><i class="el-icon-sort-down"></i></button>
         </div>
       </div>
 
@@ -44,8 +44,8 @@
 
     <!-- 列表控制按钮 -->
     <div v-show="!collapsed" class="el-button-group" v-if="!mergeConfig.disableAdd || !mergeConfig.disableDel">
-      <button @click="addItem()" v-if="!mergeConfig.disableAdd" type="button" class="el-button el-button--mini"><i class="el-icon-circle-plus-outline"></i> {{mergeConfig.addTxt || $nclang('add')}}</button>
-      <button @click="delAllItems(mergeConfig.requiredDelConfirm, mergeConfig.delConfirmText.all || $nclang('delAllTips'))" v-if="!mergeConfig.disableDel" type="button" class="el-button el-button--danger el-button--mini"><i class="el-icon-remove"></i> {{mergeConfig.delAllTxt || $nclang('delAll')}}</button>
+      <button @click="addItem()" v-if="!mergeConfig.disableAdd" :disabled="disabled" type="button" class="el-button el-button--mini"><i class="el-icon-circle-plus-outline"></i> {{mergeConfig.addTxt || $nclang('add')}}</button>
+      <button @click="delAllItems(mergeConfig.requiredDelConfirm, mergeConfig.delConfirmText.all || $nclang('delAllTips'))" v-if="!mergeConfig.disableDel" :disabled="disabled" type="button" class="el-button el-button--danger el-button--mini"><i class="el-icon-remove"></i> {{mergeConfig.delAllTxt || $nclang('delAll')}}</button>
     </div>
 
   </div>

--- a/packages/ncform/src/components/vue-ncform/form-item.vue
+++ b/packages/ncform/src/components/vue-ncform/form-item.vue
@@ -3,7 +3,7 @@
   <div :class="[(!!schema.__validationResult && !schema.__validationResult.result) ? 'invalid' : '', schema.ui.itemClass]">
 
     <!-- object 类型 -->
-    <component v-if="isNormalObjSchema(schema)" :is="'ncform-' + schema.ui.widget" :schema="schema" :form-data="formData" :temp-data="tempData" :global-const="globalConfig.constants" :idx-chain="idxChain" :config="schema.ui.widgetConfig">
+    <component v-if="isNormalObjSchema(schema)" :is="'ncform-' + schema.ui.widget" :schema="schema" v-bind="commonAttrs">
 
       <template v-for="(fieldSchema, fieldName) in schema.properties" :slot="fieldName">
         <form-item :schema="fieldSchema" :form-data="formData" :temp-data="tempData" :global-const="globalConfig.constants" :key="fieldName" :global-config="globalConfig" :idx-chain="idxChain" :complete-schema="completeSchema" :paths="paths ? paths + '.' + fieldName : fieldName" :form-name="formName"></form-item>
@@ -12,7 +12,7 @@
     </component>
 
     <!-- array 类型 -->
-    <component v-else-if="isNormalArrSchema(schema)" :is="'ncform-' + schema.ui.widget" :schema="schema" :form-data="formData" :temp-data="tempData" :global-const="globalConfig.constants" :idx-chain="idxChain" :config="schema.ui.widgetConfig" class="__ncform-control">
+    <component v-else-if="isNormalArrSchema(schema)" :is="'ncform-' + schema.ui.widget" :schema="schema" v-bind="commonAttrs" class="__ncform-control">
 
       <template v-for="(fieldSchema, fieldName) in (schema.items.properties || {__notObjItem: schema.items})" :slot="fieldName" slot-scope="props">
         <form-item :schema="props.schema" :key="fieldName" :form-data="formData" :temp-data="tempData" :global-const="globalConfig.constants" :idx-chain="(idxChain ? idxChain + ',' : '') + props.idx" :global-config="globalConfig" :complete-schema="completeSchema" :paths="paths + '[' + props.idx + ']'" :form-name="formName"></form-item>
@@ -27,12 +27,12 @@
 
     <!-- 特殊类型 COMP -->
     <template v-else-if="schema.type === 'COMP'">
-      <component :is="schema.ui.widget" :config="schema.ui.widgetConfig" :form-data="formData" :temp-data="tempData" :global-const="globalConfig.constants" :idx-chain="idxChain"></component>
+      <component :is="schema.ui.widget" v-bind="commonAttrs"></component>
     </template>
 
     <!-- string / number / integer / boolean 类型 -->
     <template v-else>
-      <component :is="'ncform-' + schema.ui.widget" :config="schema.ui.widgetConfig" v-model="schema.value" :form-data="formData" :temp-data="tempData" :global-const="globalConfig.constants" :idx-chain="idxChain" class="__ncform-control">
+      <component :is="'ncform-' + schema.ui.widget" v-model="schema.value" v-bind="commonAttrs" class="__ncform-control">
       </component>
       <div class="__ncform-item-preview" v-if="schema.ui.preview && schema.value"
         :style="{width: schema.ui.preview.outward && schema.ui.preview.outward.width ?  schema.ui.preview.outward.width + 'px' : 'auto', height: schema.ui.preview.outward && schema.ui.preview.outward.height ? schema.ui.preview.outward.height + 'px' : 'auto'}" >
@@ -159,6 +159,17 @@ export default {
   },
 
   computed: {
+    commonAttrs() {
+      return {
+        formData: this.formData,
+        tempData: this.tempData,
+        idxChain: this.idxChain,
+        config: this.schema.ui.widgetConfig,
+        globalConst: this.globalConfig.constants,
+        globalStatus: this.globalConfig.status
+      }
+    },
+
     valueTemplate() {
 
       if (!this.schema.valueTemplate) return undefined;


### PR DESCRIPTION
需求是通过一个配置将整体表单禁用，来作为简单的详情页展示数据。

通过与 `globalConst` 同级的 `disabled ` 属性来实现会更好，但是 `globalConst.disabled` 比较好获取一些。

---

The requirement is to disable the whole form through a configuration to display data as a simple detail page.

It will be better to achieve this through the `disabled` attribute at the same level as `globalconst`, but `globalconst.disabled` is better to obtain some.