### PR TITLE
chore: update webpack build config: no minify

### DIFF
--- a/packages/ncform-common/package.json
+++ b/packages/ncform-common/package.json
@@ -2,7 +2,7 @@
   "name": "@ncform/ncform-common",
   "version": "1.7.0",
   "description": "ncform common",
-  "main": "dist/ncformCommon.min.js",
+  "main": "dist/ncformCommon.js",
   "scripts": {
     "test": "mocha --recursive --require ./test/unit/testHelper.js -t 5000",
     "build": "gulp build",

--- a/packages/ncform-show/conf/webpack.config.dev.js
+++ b/packages/ncform-show/conf/webpack.config.dev.js
@@ -7,6 +7,12 @@ module.exports = {
 
   mode: 'development',
 
+  optimization: {
+    minimize: false
+  },
+
+  devtool: 'cheap-module-source-map',
+
   entry: {
     playground: path.join(config.src, "components", "playground", "index.vue"),
     schemaGen: path.join(config.src, "components", "schema-gen", "index.vue")

--- a/packages/ncform-theme-elementui/conf/webpack.config.dev.js
+++ b/packages/ncform-theme-elementui/conf/webpack.config.dev.js
@@ -8,7 +8,11 @@ const webpackConfig = {
 
   mode: 'development',
 
-  devtool: 'cheap-module-eval-source-map',
+  optimization: {
+    minimize: false
+  },
+
+  devtool: 'cheap-module-source-map',
 
   entry: {
     input: path.join(config.src, "components", "control-comps", "input.vue"),

--- a/packages/ncform-theme-elementui/package.json
+++ b/packages/ncform-theme-elementui/package.json
@@ -3,7 +3,7 @@
   "version": "1.7.0",
   "description": "ncform theme element-ui",
   "author": "daniel.xiao; kyle.lo;",
-  "main": "dist/ncformStdComps.min.js",
+  "main": "dist/ncformStdComps.js",
   "keywords": [
     "ncform",
     "theme",

--- a/packages/ncform/conf/webpack.config.dev.js
+++ b/packages/ncform/conf/webpack.config.dev.js
@@ -6,6 +6,12 @@ module.exports = {
 
   mode: 'development',
 
+  optimization: {
+    minimize: false
+  },
+
+  devtool: 'cheap-module-source-map',
+
   entry: {
     vueNcform: path.join(config.src, "components", "vue-ncform", "index.js")
   },

--- a/packages/ncform/package.json
+++ b/packages/ncform/package.json
@@ -3,7 +3,7 @@
   "version": "1.7.0",
   "description": "ncform, a very nice configuration generation way to develop form ( vue, json-schema, form, generator )",
   "author": "daniel.xiao",
-  "main": "dist/vueNcform.min.js",
+  "main": "dist/vueNcform.js",
   "keywords": [
     "vue",
     "json",


### PR DESCRIPTION
No need to use `.min.js`
Because every body will have there own build process. they can minify the code in their own process.