### PR TITLE
fix: 修复type 为 array 时,自定义 widget 组件获取不到 value 的问题

### DIFF
--- a/packages/ncform-common/src/mixins/vue/layout-array-mixin.js
+++ b/packages/ncform-common/src/mixins/vue/layout-array-mixin.js
@@ -157,7 +157,8 @@ export default {
           __dataSchema,
           true
         );
-        this.$set(this.schema.value, idx, { __dataSchema });
+        // this.$set(this.schema.value, idx, { __dataSchema });
+        this.$set(this.schema.value[idx], '__dataSchema', __dataSchema);
       }
 
       if (!this.schema.value[idx].__dataSchema.__id) {

--- a/packages/ncform/package-lock.json
+++ b/packages/ncform/package-lock.json
@@ -62,31 +62,15 @@
       }
     },
     "@ncform/ncform-common": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@ncform/ncform-common/-/ncform-common-1.7.8.tgz",
-      "integrity": "sha512-RLEZkHzmPsZKL9Gq4Vp+VBY3y2NiE9AIwUvHVkiL4xUolX+GqqyMQ+SF0/s27LfvRWtpu09hFBJdVecSmWuJCg==",
+      "version": "1.7.9",
+      "resolved": "https://mirrors.tencent.com/npm/@ncform%2fncform-common/-/ncform-common-1.7.9.tgz",
+      "integrity": "sha512-LDlCP6pb8Y2fc3rktPymWg7+zjSCsdL2Uy3MK1l6PtosVHyQWeAFdkRm07xSFkzIfhiY9iIkMltLAIPr/ODHaQ==",
       "requires": {
         "assert": "^1.4.1",
-        "axios": "^0.18.1",
+        "axios": "^0.21.1",
         "extend": "^3.0.2",
         "lodash-es": "^4.17.4",
         "power-assert": "^1.4.4"
-      },
-      "dependencies": {
-        "axios": {
-          "version": "0.18.1",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
-          "integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
-          "requires": {
-            "follow-redirects": "1.5.10",
-            "is-buffer": "^2.0.2"
-          }
-        },
-        "is-buffer": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
-          "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
-        }
       }
     },
     "@types/q": {
@@ -3789,6 +3773,7 @@
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
       "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "dev": true,
       "requires": {
         "debug": "=3.1.0"
       },
@@ -3797,6 +3782,7 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -6021,7 +6007,7 @@
     },
     "kind-of": {
       "version": "3.2.2",
-      "resolved": "https://registry.npm.taobao.org/kind-of/download/kind-of-3.2.2.tgz",
+      "resolved": "http://registry.npm.taobao.org/kind-of/download/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
@@ -7122,7 +7108,8 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "http://registry.npm.taobao.org/ms/download/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
     },
     "multipipe": {
       "version": "0.1.2",
@@ -10259,7 +10246,7 @@
       "dependencies": {
         "kind-of": {
           "version": "2.0.1",
-          "resolved": "https://registry.npm.taobao.org/kind-of/download/kind-of-2.0.1.tgz",
+          "resolved": "http://registry.npm.taobao.org/kind-of/download/kind-of-2.0.1.tgz",
           "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
           "dev": true,
           "requires": {

--- a/packages/ncform/src/components/vue-ncform/form-item.vue
+++ b/packages/ncform/src/components/vue-ncform/form-item.vue
@@ -12,7 +12,7 @@
     </component>
 
     <!-- array 类型 -->
-    <component v-else-if="isNormalArrSchema(schema)" :is="'ncform-' + schema.ui.widget" :schema="schema" :form-data="formData" :temp-data="tempData" :global-const="globalConfig.constants" :idx-chain="idxChain" :config="schema.ui.widgetConfig" class="__ncform-control">
+    <component v-else-if="isNormalArrSchema(schema)" :is="'ncform-' + schema.ui.widget" v-model="schema.value" :schema="schema" :form-data="formData" :temp-data="tempData" :global-const="globalConfig.constants" :idx-chain="idxChain" :config="schema.ui.widgetConfig" class="__ncform-control">
 
       <template v-for="(fieldSchema, fieldName) in (schema.items.properties || {__notObjItem: schema.items})" :slot="fieldName" slot-scope="props">
         <form-item :schema="props.schema" :key="fieldName" :form-data="formData" :temp-data="tempData" :global-const="globalConfig.constants" :idx-chain="(idxChain ? idxChain + ',' : '') + props.idx" :global-config="globalConfig" :complete-schema="completeSchema" :paths="paths + '[' + props.idx + ']' + (fieldName === '__notObjItem' ? '' : `.${fieldName}`)" :form-name="formName"></form-item>


### PR DESCRIPTION
对于 type=array 类型的结构，在定义子 widget 组件中，无法获取真实数组的值

翻看代码发现, schema.value 被  `__dataSchema` 完全替换掉了。不清楚为何这样处理